### PR TITLE
Change checkstyle WhitespaceAfter rule

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -249,7 +249,7 @@
 
     <!-- https://checkstyle.org/config_whitespace.html#WhitespaceAfter -->
     <module name="WhitespaceAfter">
-      <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+      <property name="tokens" value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, LITERAL_FOR"/>
     </module>
 
     <!-- https://checkstyle.org/config_whitespace.html#WhitespaceAround -->


### PR DESCRIPTION
This closes #106 by adding a Checkstyle rule that enforces whitespace after `LITERAL_IF`. I also took the liberty of adding the same check for `LITERAL_ELSE`, `LITERAL_WHILE`, and `LITERAL_FOR` - this matches the pre-existing code style in all cases.