### PR TITLE
Checkstyle rule to enforce blank line before the last } in a file

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -27,12 +27,20 @@
   <module name="SuppressWarningsFilter"/>
 
   <!-- carbon -->
-  <!-- empty line at beginning after class/interface/enum definition -->
   <!-- Temporary until https://github.com/checkstyle/checkstyle/issues/5313 -->
+  <!-- empty line at beginning after class/interface/enum definition -->
   <module name="RegexpMultiline">
     <property name="format" value="^([^\r\n ]+ )*(class|interface|enum) [^{]*\{\r?\n[^\r\n}]"/>
-    <property name="message" value="Leave empty row after class/interface/enum definition!"/>
+    <property name="message" value="Leave an empty line after class/interface/enum definition!"/>
     <property name="fileExtensions" value="groovy,java"/>
+  </module>
+
+  <!-- empty line before the last } of class/interface/enum definition -->
+  <module name="RegexpMultiline">
+    <property name="format" value="}\r\n}\r\n\Z"/>
+    <property name="message" value="Leave an empty line before the last } of class/interface/enum!"/>
+    <property name="fileExtensions" value="groovy,java"/>
+    <property name="matchAcrossLines" value="true"/>
   </module>
 
   <!-- https://checkstyle.org/config_filters.html#SuppressWithPlainTextCommentFilter -->


### PR DESCRIPTION
As the title suggests, this PR adds a Checkstyle rule to make sure there's a blank line before the last `}` in a file. For example, this will now throw an error:
```java
public class Bird {

    public void chirp() {
        asdf();
    } // violation
}
```
Instead, this should be used:
```java
public class Bird {

    public void chirp() {
        asdf();
    }

}
```
Unfortunately, this regular expression (which you can play with [here](https://regex101.com/r/mWwV6h/1)) won't detect this issue within subclasses (of which there aren't any in the codebase, yet) - it only will match it at the very end of the file. If anybody has a better way to do this where it'll match subclasses, I'm open to suggestions.