### PR TITLE
Add ImageFontTransformation

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageRenderer.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageRenderer.java
@@ -12,6 +12,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.minimessage.template.TemplateResolver;
+import net.kyori.adventure.text.minimessage.transformation.TransformationRegistry;
+import net.kyori.adventure.text.minimessage.transformation.TransformationType;
 import net.kyori.moonshine.message.IMessageRenderer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -20,10 +22,18 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 public class CarbonMessageRenderer implements IMessageRenderer<Audience, String, Component, Component> {
 
     private final PrimaryConfig config;
+    private final MiniMessage miniMessage;
 
     @Inject
     public CarbonMessageRenderer(final PrimaryConfig config) {
         this.config = config;
+
+        final var transformationNames = TransformationType.acceptingNames("image_font");
+        final var transformationType = TransformationType.transformationType(transformationNames,
+            (name, args) -> new ImageFontTransformation(args));
+        final var registry = TransformationRegistry.standard().toBuilder().add(transformationType).build();
+
+        this.miniMessage = MiniMessage.builder().transformations(registry).build();
     }
 
     @Override
@@ -49,7 +59,7 @@ public class CarbonMessageRenderer implements IMessageRenderer<Audience, String,
                 entry.getValue());
         }
         
-        return MiniMessage.miniMessage().deserialize(placeholderResolvedMessage, TemplateResolver.templates(templates));
+        return this.miniMessage.deserialize(placeholderResolvedMessage, TemplateResolver.templates(templates));
     }
 
 }

--- a/common/src/main/java/net/draycia/carbon/common/messages/ImageFontTransformation.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/ImageFontTransformation.java
@@ -1,0 +1,68 @@
+package net.draycia.carbon.common.messages;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.TextReplacementConfig;
+import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
+import net.kyori.adventure.text.minimessage.parser.node.TagPart;
+import net.kyori.adventure.text.minimessage.transformation.Modifying;
+import net.kyori.adventure.text.minimessage.transformation.Transformation;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.framework.qual.DefaultQualifier;
+
+@DefaultQualifier(NonNull.class)
+public class ImageFontTransformation extends Transformation implements Modifying {
+
+    final Component nbsp = Component.translatable("space.-1");
+    final JoinConfiguration joinConfiguration = JoinConfiguration.separator(nbsp);
+    final List<TagPart> args;
+
+    public ImageFontTransformation(List<TagPart> args) {
+        this.args = args;
+    }
+
+    @Override
+    public void visit(final ElementNode curr) {
+
+    }
+
+    @Override
+    public Component apply(final Component curr, final int depth) {
+        final var siblings = new ArrayList<ComponentLike>();
+
+        curr.replaceText(TextReplacementConfig.builder()
+                .match(Pattern.compile("[^\\uF801]"))
+                .replacement(builder -> {
+                    // We do this instead of just in place replacing
+                    // Returning the result of the replacement results in "grouped" components of the builder and translatable
+                    // This results in render errors
+                    // The goal here is to make ALL characters and translatable components siblings
+                    siblings.add(builder);
+
+                    return builder;
+                })
+                .build());
+
+        return Component.join(this.joinConfiguration, siblings);
+    }
+
+    @Override
+    public Component apply() {
+        return Component.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+}


### PR DESCRIPTION
Inserts -1pixel width "spaces" into the input, so image based fonts may render without a margin/padding.

TODO:
- [ ] Solve parsing issues
- [ ] Accept font name in tag args
- [ ] Require separator in tag args