### PR TITLE
feat: Nickname tag resolver permissions

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
@@ -131,7 +131,7 @@ public class NicknameCommand extends CarbonCommand {
                         final var builder = MiniMessage.builder()
                             .tags(this.resolver(sender))
                             .build();
-                        builder.deserialize(builder.stripTags(handler.flags().get("nickname")));
+                        ref.cached = builder.deserialize(handler.flags().get("nickname"));
 
                         return ref.cached;
                     };

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
@@ -128,10 +128,8 @@ public class NicknameCommand extends CarbonCommand {
                     final Supplier<Component> lazyNickname = () -> {
                         if (ref.cached != null) return ref.cached;
 
-                        final var resolver = this.resolver(sender);
-
                         final var builder = MiniMessage.builder()
-                            .tags(resolver.build())
+                            .tags(this.resolver(sender))
                             .build();
                         builder.deserialize(builder.stripTags(handler.flags().get("nickname")));
 
@@ -184,9 +182,12 @@ public class NicknameCommand extends CarbonCommand {
 
     private final String[] styleStrings = {"color", "gradient", "decorations", "hoverEvent", "clickEvent", "insertion", "rainbow", "reset"};
 
-    private TagResolver.Builder resolver(final CarbonPlayer carbonPlayer) {
-        final var resolver = TagResolver.builder();
+    private TagResolver resolver(final CarbonPlayer carbonPlayer) {
+        if (carbonPlayer.hasPermission("carbon.nickname.style.*")) {
+            return TagResolver.standard();
+        }
 
+        final var resolver = TagResolver.builder();
         for (final String style : this.styleStrings) {
             if (carbonPlayer.hasPermission("carbon.nickname.style.%s".formatted(style))) {
                 try {
@@ -197,7 +198,7 @@ public class NicknameCommand extends CarbonCommand {
             }
         }
 
-        return resolver;
+        return resolver.build();
     }
 
 }

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -109,6 +109,30 @@ bukkit {
     register("carbon.nickname.set") {
       description = "Sets your/other player's nicknames."
     }
+    register("carbon.nickname.style.color") {
+      description = "Allows the use of colors in nicknames."
+    }
+    register("carbon.nickname.style.gradient") {
+      description = "Allows the use of gradients in nicknames."
+    }
+    register("carbon.nickname.style.decorations") {
+      description = "Allows the use of decorations in nicknames."
+    }
+    register("carbon.nickname.style.hoverEvent") {
+      description = "Allows the use of hover events in nicknames."
+    }
+    register("carbon.nickname.style.clickEvent") {
+      description = "Allows the use of click events in nicknames."
+    }
+    register("carbon.nickname.style.insertion") {
+      description = "Allows the use of insertions in nicknames."
+    }
+    register("carbon.nickname.style.rainbow") {
+      description = "Allows the use of the rainbow tag in nicknames."
+    }
+    register("carbon.nickname.style.reset") {
+      description = "Allows the use of the reset tag in nicknames."
+    }
     register("carbon.reload") {
       description = "Reloads Carbon's config, channel settings, and translations."
     }


### PR DESCRIPTION
This allows the user to be permitted only partial minimessage usage in their nicknames.