### PR TITLE
DiscordSRV bridge fixes

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
@@ -323,7 +323,6 @@ public class CarbonChannelRegistry implements ChannelRegistry, DefaultedRegistry
         // TODO: add previewing when cloud/adventure support it
         final var chatEvent = new CarbonChatEvent(sender, Component.text(plainMessage), recipients, renderers, channel, false);
         final var result = this.carbonChat.eventHandler().emit(chatEvent);
-
         if (!result.wasSuccessful()) {
             final var message = chatEvent.result().reason();
 
@@ -333,19 +332,15 @@ public class CarbonChannelRegistry implements ChannelRegistry, DefaultedRegistry
 
             return;
         }
-
         var renderedMessage = new RenderedMessage(chatEvent.message(), MessageType.CHAT);
-
         for (final var renderer : chatEvent.renderers()) {
             renderedMessage = renderer.render(sender, sender, renderedMessage.component(), chatEvent.message());
         }
-
         final Identity identity = sender.hasPermission("carbon.hideidentity") ? Identity.nil() : sender.identity();
 
         for (final Audience recipient : chatEvent.recipients()) {
             recipient.sendMessage(identity, renderedMessage.component(), renderedMessage.messageType());
         }
-
         final @Nullable PacketService packetService = this.carbonChat.packetService();
 
         if (packetService != null) {

--- a/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
@@ -323,6 +323,7 @@ public class CarbonChannelRegistry implements ChannelRegistry, DefaultedRegistry
         // TODO: add previewing when cloud/adventure support it
         final var chatEvent = new CarbonChatEvent(sender, Component.text(plainMessage), recipients, renderers, channel, false);
         final var result = this.carbonChat.eventHandler().emit(chatEvent);
+
         if (!result.wasSuccessful()) {
             final var message = chatEvent.result().reason();
 
@@ -332,15 +333,19 @@ public class CarbonChannelRegistry implements ChannelRegistry, DefaultedRegistry
 
             return;
         }
+
         var renderedMessage = new RenderedMessage(chatEvent.message(), MessageType.CHAT);
+
         for (final var renderer : chatEvent.renderers()) {
             renderedMessage = renderer.render(sender, sender, renderedMessage.component(), chatEvent.message());
         }
+
         final Identity identity = sender.hasPermission("carbon.hideidentity") ? Identity.nil() : sender.identity();
 
         for (final Audience recipient : chatEvent.recipients()) {
             recipient.sendMessage(identity, renderedMessage.component(), renderedMessage.messageType());
         }
+
         final @Nullable PacketService packetService = this.carbonChat.packetService();
 
         if (packetService != null) {

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
@@ -82,10 +82,9 @@ public final class PaperChatListener implements Listener {
         final var playerResult = this.carbonChat.server().userManager().carbonPlayer(event.getPlayer().getUniqueId()).join();
         final @Nullable CarbonPlayer sender = playerResult.player();
 
-        if (sender == null) {
+        if (sender == null || event.viewers().isEmpty()) {
             return;
         }
-
         var channel = requireNonNullElse(sender.selectedChannel(), this.registry.defaultValue());
         final var messageContents = PlainTextComponentSerializer.plainText().serialize(event.message());
         Component eventMessage = ConfigChatChannel.parseMessageTags(sender, messageContents);

--- a/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
@@ -167,9 +167,7 @@ public final class CarbonPlayerPaper extends WrappedCarbonPlayer implements Forw
     @Override
     public boolean speechPermitted(final String message) {
         // ...........
-        return new AsyncPlayerChatEvent(!Bukkit.isPrimaryThread(), this.player().get(), message, Set.of()).callEvent()
-            && new AsyncChatEvent(!Bukkit.isPrimaryThread(), this.player().get(), Set.of(),
-            (player, name, msg, receiver) -> msg, Component.text(message), Component.text(message)).callEvent();
+        return new AsyncPlayerChatEvent(!Bukkit.isPrimaryThread(), this.player().get(), message, Set.of()).callEvent() && new AsyncChatEvent(!Bukkit.isPrimaryThread(), this.player().get(), Set.of(), (player, name, msg, receiver) -> msg, Component.text(message), Component.text(message)).callEvent();
     }
 
     @Override

--- a/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
@@ -74,8 +74,7 @@ public class DSRVChatHook implements ChatHook {
             awaitingEvent.invalidate(pair);
 
             if (messageComponent == null) {
-                System.out.println("message component is null");
-                return;
+                messageComponent = event.message();
             }
 
             var renderedMessage = new RenderedMessage(messageComponent, MessageType.CHAT);

--- a/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
@@ -70,7 +70,7 @@ public class DSRVChatHook implements ChatHook {
             final ChatChannel chatChannel = event.chatChannel();
             final CarbonPlayer carbonPlayer = event.sender();
             final ImmutablePair<CarbonPlayer, ChatChannel> pair = new ImmutablePair<>(carbonPlayer, chatChannel);
-            final Component messageComponent = awaitingEvent.getIfPresent(pair);
+            Component messageComponent = awaitingEvent.getIfPresent(pair);
             awaitingEvent.invalidate(pair);
 
             if (messageComponent == null) {

--- a/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
@@ -61,7 +61,6 @@ public class DSRVChatHook implements ChatHook {
 
         CarbonChatProvider.carbonChat().eventHandler().subscribe(CarbonChatEvent.class, event -> {
             if (event.previewing()) {
-                System.out.println("previewing");
                 final var pair = new ImmutablePair<>(event.sender(), event.chatChannel());
                 awaitingEvent.put(pair, event.message());
                 return;
@@ -99,11 +98,9 @@ public class DSRVChatHook implements ChatHook {
 
             final @Nullable Player player = ((CarbonPlayerPaper) carbonPlayer).bukkitPlayer();
             final String message = PlainTextComponentSerializer.plainText().serialize(eventMessage);
-            System.out.println("sending null check");
-            
+
             if (player != null) {
                 DiscordSRV.getPlugin().processChatMessage(player, message, chatChannel.commandName(), event.result().cancelled());
-                System.out.println("sending");
             }
         });
 

--- a/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/util/DSRVChatHook.java
@@ -61,6 +61,7 @@ public class DSRVChatHook implements ChatHook {
 
         CarbonChatProvider.carbonChat().eventHandler().subscribe(CarbonChatEvent.class, event -> {
             if (event.previewing()) {
+                System.out.println("previewing");
                 final var pair = new ImmutablePair<>(event.sender(), event.chatChannel());
                 awaitingEvent.put(pair, event.message());
                 return;
@@ -73,6 +74,7 @@ public class DSRVChatHook implements ChatHook {
             awaitingEvent.invalidate(pair);
 
             if (messageComponent == null) {
+                System.out.println("message component is null");
                 return;
             }
 
@@ -98,9 +100,11 @@ public class DSRVChatHook implements ChatHook {
 
             final @Nullable Player player = ((CarbonPlayerPaper) carbonPlayer).bukkitPlayer();
             final String message = PlainTextComponentSerializer.plainText().serialize(eventMessage);
-
+            System.out.println("sending null check");
+            
             if (player != null) {
                 DiscordSRV.getPlugin().processChatMessage(player, message, chatChannel.commandName(), event.result().cancelled());
+                System.out.println("sending");
             }
         });
 


### PR DESCRIPTION
This pull request fixes the issue with each individual channel command wouldn't trigger the carbon chat event properly for Discord support due to it have an invalid message component as preview is disabled.

It now checks if the message component is null it then resigning it to from the event's message. 
One problem i encountered doing this is that it would trigger twice due to CarbonPlayer#speechPermitted triggering the chat event and then the carbon event. I fixed this by checking if the recipients are empty in papers chat event, as what's the point?

The first 3 commits we're just debugging but in the end commit I've removed them and implemented the fixes :)