### PR TITLE
PingHandler prefix fix

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/listeners/PingHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/PingHandler.java
@@ -57,7 +57,7 @@ public class PingHandler {
                         recipient.playSound(configFactory.primaryConfig().pings().sound());
                     }
 
-                    return Component.text(prefix + matchedText.content()).color(configFactory.primaryConfig().pings().highlightTextColor());
+                    return Component.text(matchedText.content()).color(configFactory.primaryConfig().pings().highlightTextColor());
                 })
                 .build());
         });


### PR DESCRIPTION
This pull request is a fix for the ping handler including the prefix in the message even though its already been added which causes the prefix to appear twice.

Instead, it now appears once