### PR TITLE
Fix setting nicknames for others

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
@@ -119,11 +119,11 @@ public class NicknameCommand extends CarbonCommand {
     private void applyNickname(final Commander sender, final CarbonPlayer target, final String nick) {
         // Lazy since the sender might not have permission to set the nickname
         final Supplier<Component> parsedNick = Suppliers.memoize(() -> parseNickname(sender, nick));
+        target.displayName(parsedNick.get());
 
         if (sender instanceof PlayerCommander playerCommander
             && playerCommander.carbonPlayer().uuid().equals(target.uuid())) {
             // Setting own nickname
-            target.displayName(parsedNick.get());
             this.carbonMessages.nicknameSet(sender, parsedNick.get());
         } else {
             // Setting other player's nickname


### PR DESCRIPTION
Setting nicknames for others never worked, because `target.displayName(parsedNick.get())` was only ever called when the player sets their own nickname. That method should be called either way though, and doing so fixes this issue.