### PR TITLE
Describe valid StorageTypes in PrimaryConfig.java

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
@@ -43,7 +43,11 @@ public class PrimaryConfig {
     """)
     private Key defaultChannel = Key.key("carbon", "global");
 
-    @Comment("The service that will be used to store and load player information.")
+    @Comment("""
+    The service that will be used to store and load player information.
+    One of: JSON, MYSQL, or PSQL.
+    NB: If you choose MYSQL or PSQL make sure you configure the "database-settings" section of this file!
+    """)
     private StorageType storageType = StorageType.JSON;
 
     @Comment("")


### PR DESCRIPTION
When configuring the plugin I was unsure of what the valid options were for `storage-type` in the config file. This PR adds a comment to the config file that reads:

```
# The service that will be used to store and load player information.
# One of: JSON, MYSQL, or PSQL.
# NB: If you choose MYSQL or PSQL make sure you configure the "database-settings" section of this file!
```

This is based upon the [StorageTypes Enum in PrimaryConfig.java](https://github.com/Hexaoxide/Carbon/blob/2.1/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java#L143)