### PR TITLE
Fix reloads by recreating the channel registry

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
@@ -26,6 +26,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
+import com.seiama.event.EventConfig;
 import com.seiama.registry.Registry;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -115,7 +116,7 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
         this.carbonMessages = carbonMessages;
         this.eventHandler = events;
 
-        events.subscribe(CarbonReloadEvent.class, event -> this.reloadConfigChannels());
+        events.subscribe(CarbonReloadEvent.class, -99, EventConfig.DEFAULT_ACCEPTS_CANCELLED, event -> this.reloadConfigChannels());
     }
 
     public static ConfigurationTransformation.Versioned versioned() {

--- a/common/src/main/java/net/draycia/carbon/common/config/ConfigFactory.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/ConfigFactory.java
@@ -21,6 +21,7 @@ package net.draycia.carbon.common.config;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.seiama.event.EventConfig;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -56,7 +57,7 @@ public class ConfigFactory {
         this.dataDirectory = dataDirectory;
         this.locale = locale;
 
-        events.subscribe(CarbonReloadEvent.class, event -> this.reloadPrimaryConfig());
+        events.subscribe(CarbonReloadEvent.class, -100, EventConfig.DEFAULT_ACCEPTS_CANCELLED, event -> this.reloadPrimaryConfig());
     }
 
     public @Nullable PrimaryConfig reloadPrimaryConfig() {

--- a/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSource.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSource.java
@@ -21,6 +21,7 @@ package net.draycia.carbon.common.messages;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.seiama.event.EventConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -86,7 +87,7 @@ public final class CarbonMessageSource implements IMessageSource<Audience, Strin
 
         this.reloadTranslations();
 
-        events.subscribe(CarbonReloadEvent.class, event -> {
+        events.subscribe(CarbonReloadEvent.class, -99, EventConfig.DEFAULT_ACCEPTS_CANCELLED, event -> {
             this.reloadTranslations();
         });
     }


### PR DESCRIPTION
Currently, this persists API-registered entries. Not sure if that's what we want to do, or if we should have an event for registering channels instead...

We only support registering commands for channels added at startup anyways.