### PR TITLE
Rework channel registration

### DIFF
--- a/api/src/main/java/net/draycia/carbon/api/CarbonChat.java
+++ b/api/src/main/java/net/draycia/carbon/api/CarbonChat.java
@@ -29,8 +29,13 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 
 /**
- * The main plugin interface.<br>
- * Instances may be obtained through {@link CarbonChatProvider#carbonChat()}.
+ * The main plugin interface.
+ *
+ * <p>Instances may be obtained through {@link CarbonChatProvider#carbonChat()} once Carbon is loaded.</p>
+ * <p>On most platforms, you should use the provided load order mechanism to ensure your addon loads after
+ * Carbon.</p>
+ * <p>On Fabric, use the {@code carbonchat} entrypoint (type: {@code Consumer<CarbonChat>}) to have a callback
+ * when Carbon is loaded.</p>
  *
  * @since 1.0.0
  */

--- a/api/src/main/java/net/draycia/carbon/api/channels/ChannelRegistry.java
+++ b/api/src/main/java/net/draycia/carbon/api/channels/ChannelRegistry.java
@@ -20,6 +20,7 @@
 package net.draycia.carbon.api.channels;
 
 import java.util.Set;
+import java.util.function.Consumer;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -32,15 +33,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public interface ChannelRegistry {
 
     /**
-     * Registers ingame commands for the channel.
+     * Registers the chat channel with its key.
      *
-     * @param channel the channel to register commands for
-     * @since 2.1.0
-     */
-    void registerChannelCommands(final ChatChannel channel);
-
-    /**
-     * Registers the chat channel with it's key.
+     * <p>Registrations will persist when reloading Carbon's configuration.</p>
      *
      * @param channel the channel to register
      * @since 2.1.0
@@ -88,5 +83,16 @@ public interface ChannelRegistry {
      * @since 2.1.0
      */
     ChatChannel keyOrDefault(final Key key);
+
+    /**
+     * The provided action will be executed immediately for all currently registered
+     * channels.
+     *
+     * <p>When new channels are registered, the action will be invoked again for each new channel.</p>
+     *
+     * @param action action
+     * @since 2.1.0
+     */
+    void allKeys(Consumer<Key> action);
 
 }

--- a/api/src/main/java/net/draycia/carbon/api/event/events/CarbonChannelRegisterEvent.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/events/CarbonChannelRegisterEvent.java
@@ -20,14 +20,19 @@
 package net.draycia.carbon.api.event.events;
 
 import java.util.Set;
-import net.draycia.carbon.api.channels.ChatChannel;
+import java.util.function.Consumer;
+import net.draycia.carbon.api.channels.ChannelRegistry;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 
 /**
- * {@link CarbonEvent} that's called when channels are registered.
+ * {@link CarbonEvent} that's called after new channels are registered.
+ *
+ * <p>Note that some invocations of this event may be too early for
+ * API consumers to be notified. Prefer using {@link ChannelRegistry#allKeys(Consumer)}
+ * when knowledge of all registered channels is needed.</p>
  *
  * @since 2.1.0
  */
@@ -35,21 +40,19 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 public interface CarbonChannelRegisterEvent extends CarbonEvent {
 
     /**
-     * The channels that were registered.
+     * Gets the channel registry.
      *
-     * @return the registered channels
+     * @return the channel registry
      * @since 2.1.0
      */
-    Set<Key> channelKeys();
+    ChannelRegistry channelRegistry();
 
     /**
-     * Registers additional channels to the registry. Does not re-emit the event.
+     * Gets the key(s) that were registered to trigger this event.
      *
-     * @param key The key the channel is identified with in the registry
-     * @param channel the channel to register
-     * @param registerCommands if commands for the channel should be registered
+     * @return key(s) registered
      * @since 2.1.0
      */
-    void register(final Key key, final ChatChannel channel, final boolean registerCommands);
+    Set<Key> registered();
 
 }

--- a/common/src/main/java/net/draycia/carbon/common/event/events/ChannelRegisterEventImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/ChannelRegisterEventImpl.java
@@ -20,48 +20,16 @@
 package net.draycia.carbon.common.event.events;
 
 import java.util.Set;
-import net.draycia.carbon.api.channels.ChatChannel;
-import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.event.events.CarbonChannelRegisterEvent;
 import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
 
-/**
- * {@link CarbonEvent} that's called when channels are registered.
- *
- * @since 2.1.0
- */
 @DefaultQualifier(NonNull.class)
-public class ChannelRegisterEventImpl implements CarbonChannelRegisterEvent {
-
-    private final Set<Key> channelKeys;
-    private final CarbonChannelRegistry registry;
-
-    /**
-     * {@link CarbonEvent} that's called when channels are registered.
-     *
-     * @param channelKeys the channels that were registered
-     * @since 2.1.0
-     */
-    public ChannelRegisterEventImpl(final Set<Key> channelKeys, final CarbonChannelRegistry registry) {
-        this.channelKeys = channelKeys;
-        this.registry = registry;
-    }
-
-    @Override
-    public Set<Key> channelKeys() {
-        return this.channelKeys;
-    }
-
-    @Override
-    public void register(final Key key, final ChatChannel channel, final boolean registerCommands) {
-        this.registry.register(channel);
-
-        if (registerCommands) {
-            this.registry.registerChannelCommands(channel);
-        }
-    }
+public record ChannelRegisterEventImpl(
+    CarbonChannelRegistry channelRegistry,
+    Set<Key> registered
+) implements CarbonChannelRegisterEvent {
 
 }


### PR DESCRIPTION
Addons should now register any new channels as early as possible to allow for command registration.

Removing channels requires a plugin restart.