### PR TITLE
improve config management

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/CarbonChatInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/CarbonChatInternal.java
@@ -33,7 +33,7 @@ import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.users.UserManager;
 import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.draycia.carbon.common.command.ExecutionCoordinatorHolder;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.listeners.Listener;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.messaging.MessagingManager;
@@ -102,8 +102,7 @@ public abstract class CarbonChatInternal implements CarbonChat {
         // Commands
         // This is a bit awkward looking
         CloudUtils.loadCommands(this.injector);
-        final var commandSettings = CloudUtils.loadCommandSettings(this.injector);
-        CloudUtils.registerCommands(commandSettings);
+        CloudUtils.registerCommands(this.injector.getInstance(ConfigManager.class).loadCommandSettings());
 
         this.periodicTasks.scheduleAtFixedRate(
             () -> PlayerUtils.saveLoggedInPlayers(this.carbonServer, this.userManager, this.logger),
@@ -128,7 +127,7 @@ public abstract class CarbonChatInternal implements CarbonChat {
         this.channelRegistry().loadConfigChannels(this.carbonMessages);
 
         CompletableFuture.runAsync(() -> {
-            if (!this.injector.getInstance(ConfigFactory.class).primaryConfig().updateChecker()) {
+            if (!this.injector.getInstance(ConfigManager.class).primaryConfig().updateChecker()) {
                 return;
             }
             new UpdateChecker(this.logger).checkVersion();

--- a/common/src/main/java/net/draycia/carbon/common/CarbonCommonModule.java
+++ b/common/src/main/java/net/draycia/carbon/common/CarbonCommonModule.java
@@ -31,7 +31,6 @@ import com.google.inject.assistedinject.FactoryProvider3;
 import com.google.inject.multibindings.Multibinder;
 import io.leangen.geantyref.TypeToken;
 import java.lang.invoke.MethodHandles;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import net.draycia.carbon.api.channels.ChannelRegistry;
@@ -41,7 +40,7 @@ import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.draycia.carbon.common.command.ArgumentFactory;
 import net.draycia.carbon.common.command.ExecutionCoordinatorHolder;
 import net.draycia.carbon.common.command.argument.PlayerSuggestions;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.CarbonEventHandlerImpl;
 import net.draycia.carbon.common.listeners.DeafenHandler;
 import net.draycia.carbon.common.listeners.HyperlinkHandler;
@@ -90,8 +89,8 @@ public final class CarbonCommonModule extends AbstractModule {
     @Provides
     @Backing
     @Singleton
-    public UserManagerInternal<CarbonPlayerCommon> userManager(final ConfigFactory configFactory, final Injector injector) {
-        return switch (Objects.requireNonNull(configFactory.primaryConfig()).storageType()) {
+    public UserManagerInternal<CarbonPlayerCommon> userManager(final ConfigManager configManager, final Injector injector) {
+        return switch (configManager.primaryConfig().storageType()) {
             case MYSQL -> injector.getInstance(MySQLUserManager.Factory.class).create();
             case PSQL -> injector.getInstance(PostgreSQLUserManager.Factory.class).create();
             default -> injector.getInstance(JSONUserManager.class);

--- a/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
@@ -49,7 +49,7 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.DataDirectory;
 import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
 import net.draycia.carbon.common.event.events.CarbonReloadEvent;
 import net.draycia.carbon.common.event.events.ChannelRegisterEventImpl;
@@ -90,7 +90,7 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
     private final Path configChannelDir;
     private final Injector injector;
     private final Logger logger;
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
     private @MonotonicNonNull Key defaultKey;
     private final CarbonMessages carbonMessages;
     private final CarbonEventHandler eventHandler;
@@ -105,15 +105,15 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
         @DataDirectory final Path dataDirectory,
         final Injector injector,
         final Logger logger,
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final CarbonMessages carbonMessages,
         final CarbonEventHandler events
     ) {
-        super(events, carbonMessages, configFactory);
+        super(events, carbonMessages, configManager);
         this.configChannelDir = dataDirectory.resolve("channels");
         this.injector = injector;
         this.logger = logger;
-        this.configFactory = configFactory;
+        this.configManager = configManager;
         this.carbonMessages = carbonMessages;
         this.eventHandler = events;
 
@@ -212,7 +212,7 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
     }
 
     private void loadConfigChannels_(final CarbonMessages messages) {
-        this.defaultKey = this.configFactory.primaryConfig().defaultChannel();
+        this.defaultKey = this.configManager.primaryConfig().defaultChannel();
 
         List<Path> channelConfigs = FileUtil.listDirectoryEntries(this.configChannelDir, "*.conf");
         if (channelConfigs.isEmpty()) {
@@ -259,7 +259,7 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
         try {
             final Path configFile = this.configChannelDir.resolve("global.conf");
             final ConfigChatChannel configChannel = this.injector.getInstance(ConfigChatChannel.class);
-            final ConfigurationLoader<?> loader = this.configFactory.configurationLoader(FileUtil.mkParentDirs(configFile));
+            final ConfigurationLoader<?> loader = this.configManager.configurationLoader(FileUtil.mkParentDirs(configFile));
             final ConfigurationNode node = loader.createNode();
             node.set(ConfigChatChannel.class, configChannel);
             loader.save(node);
@@ -269,7 +269,7 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
     }
 
     private @Nullable ChatChannel loadChannel(final Path channelFile) {
-        final ConfigurationLoader<?> loader = this.configFactory.configurationLoader(channelFile);
+        final ConfigurationLoader<?> loader = this.configManager.configurationLoader(channelFile);
 
         try {
             final ConfigurationNode loaded = updateNode(loader.load());

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/ClearChatCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/ClearChatCommand.java
@@ -27,7 +27,7 @@ import net.draycia.carbon.common.command.CarbonCommand;
 import net.draycia.carbon.common.command.CommandSettings;
 import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
@@ -39,19 +39,19 @@ public final class ClearChatCommand extends CarbonCommand {
 
     private final CarbonServer server;
     private final CommandManager<Commander> commandManager;
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
     private final CarbonMessages carbonMessages;
 
     @Inject
     public ClearChatCommand(
         final CarbonServer server,
         final CommandManager<Commander> commandManager,
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final CarbonMessages carbonMessages
     ) {
         this.server = server;
         this.commandManager = commandManager;
-        this.configFactory = configFactory;
+        this.configManager = configManager;
         this.carbonMessages = carbonMessages;
     }
 
@@ -74,10 +74,10 @@ public final class ClearChatCommand extends CarbonCommand {
             .handler(handler -> {
                 // Not fond of having to send 50 messages to each player
                 // Are we not able to just paste in 50 newlines and call it a day?
-                for (int i = 0; i < this.configFactory.primaryConfig().clearChatSettings().iterations(); i++) {
+                for (int i = 0; i < this.configManager.primaryConfig().clearChatSettings().iterations(); i++) {
                     for (final var player : this.server.players()) {
                         if (!player.hasPermission("carbon.clearchat.exempt")) {
-                            player.sendMessage(this.configFactory.primaryConfig().clearChatSettings().message());
+                            player.sendMessage(this.configManager.primaryConfig().clearChatSettings().message());
                         }
                     }
                 }
@@ -93,7 +93,7 @@ public final class ClearChatCommand extends CarbonCommand {
                     username = "Console";
                 }
 
-                this.server.sendMessage(this.configFactory.primaryConfig().clearChatSettings()
+                this.server.sendMessage(this.configManager.primaryConfig().clearChatSettings()
                     .broadcast(senderName, username));
             })
             .build();

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
@@ -32,7 +32,7 @@ import net.draycia.carbon.common.command.CarbonCommand;
 import net.draycia.carbon.common.command.CommandSettings;
 import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.users.WrappedCarbonPlayer;
 import net.draycia.carbon.common.util.CloudUtils;
@@ -48,14 +48,14 @@ public final class NicknameCommand extends CarbonCommand {
     private final CommandManager<Commander> commandManager;
     private final CarbonMessages carbonMessages;
     private final ArgumentFactory argumentFactory;
-    private final ConfigFactory config;
+    private final ConfigManager config;
 
     @Inject
     public NicknameCommand(
         final CommandManager<Commander> commandManager,
         final CarbonMessages carbonMessages,
         final ArgumentFactory argumentFactory,
-        final ConfigFactory config
+        final ConfigManager config
     ) {
         this.commandManager = commandManager;
         this.carbonMessages = carbonMessages;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/WhisperCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/WhisperCommand.java
@@ -36,7 +36,7 @@ import net.draycia.carbon.common.command.CommandSettings;
 import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.command.argument.CarbonPlayerArgument;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonPrivateChatEventImpl;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.messages.SourcedAudience;
@@ -116,7 +116,7 @@ public final class WhisperCommand extends CarbonCommand {
 
         private final Logger logger;
         private final CarbonMessages messages;
-        private final ConfigFactory configFactory;
+        private final ConfigManager configManager;
         private final Provider<MessagingManager> messaging;
         private final PacketFactory packetFactory;
         private final UserManager<? extends CarbonPlayer> userManager;
@@ -128,7 +128,7 @@ public final class WhisperCommand extends CarbonCommand {
         private WhisperHandler(
             final Logger logger,
             final CarbonMessages messages,
-            final ConfigFactory configFactory,
+            final ConfigManager configManager,
             final Provider<MessagingManager> messaging,
             final PacketFactory packetFactory,
             final UserManager<?> userManager,
@@ -138,7 +138,7 @@ public final class WhisperCommand extends CarbonCommand {
         ) {
             this.logger = logger;
             this.messages = messages;
-            this.configFactory = configFactory;
+            this.configManager = configManager;
             this.messaging = messaging;
             this.packetFactory = packetFactory;
             this.userManager = userManager;
@@ -204,7 +204,7 @@ public final class WhisperCommand extends CarbonCommand {
             }
             this.messages.whisperConsoleLog(this.server.console(), senderName, recipientName, privateChatEvent.message());
 
-            final @Nullable Sound messageSound = this.configFactory.primaryConfig().messageSound();
+            final @Nullable Sound messageSound = this.configManager.primaryConfig().messageSound();
             if (localRecipient && messageSound != null) {
                 recipient.playSound(messageSound);
             }
@@ -235,7 +235,7 @@ public final class WhisperCommand extends CarbonCommand {
                 recipient.whisperReplyTarget(sender.uuid());
                 this.messages.whisperRecipient(SourcedAudience.of(sender, recipient), senderName, recipientName, packet.message());
                 this.messages.whisperConsoleLog(this.server.console(), senderName, recipientName, packet.message());
-                final @Nullable Sound messageSound = this.configFactory.primaryConfig().messageSound();
+                final @Nullable Sound messageSound = this.configManager.primaryConfig().messageSound();
                 if (messageSound != null) {
                     recipient.playSound(messageSound);
                 }

--- a/common/src/main/java/net/draycia/carbon/common/config/ConfigManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/ConfigManager.java
@@ -24,11 +24,14 @@ import com.google.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Map;
 import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.common.DataDirectory;
+import net.draycia.carbon.common.command.CommandSettings;
 import net.draycia.carbon.common.event.events.CarbonReloadEvent;
 import net.draycia.carbon.common.serialisation.gson.LocaleSerializerConfigurate;
 import net.draycia.carbon.common.util.FileUtil;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.serializer.configurate4.ConfigurateComponentSerializer;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -91,8 +94,12 @@ public final class ConfigManager {
         return this.primaryConfig;
     }
 
-    public @Nullable CommandConfig loadCommandSettings() {
-        return this.load(CommandConfig.class, COMMAND_SETTINGS_FILE_NAME);
+    public Map<Key, CommandSettings> loadCommandSettings() {
+        final @Nullable CommandConfig load = this.load(CommandConfig.class, COMMAND_SETTINGS_FILE_NAME);
+        if (load == null) {
+            throw new RuntimeException("Failed to initialize command settings, see above for further details");
+        }
+        return load.settings();
     }
 
     public ConfigurationLoader<?> configurationLoader(final Path file) {

--- a/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
@@ -26,7 +26,7 @@ import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.util.KeyedRenderer;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
 import net.draycia.carbon.common.event.events.CarbonEarlyChatEvent;
 import net.draycia.carbon.common.messages.CarbonMessages;
@@ -45,16 +45,16 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 @DefaultQualifier(NonNull.class)
 public abstract class ChatListenerInternal {
 
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
     private final CarbonMessages carbonMessages;
     private final CarbonEventHandler carbonEventHandler;
 
     protected ChatListenerInternal(
         final CarbonEventHandler carbonEventHandler,
         final CarbonMessages carbonMessages,
-        final ConfigFactory configFactory
+        final ConfigManager configManager
     ) {
-        this.configFactory = configFactory;
+        this.configManager = configManager;
         this.carbonMessages = carbonMessages;
         this.carbonEventHandler = carbonEventHandler;
     }
@@ -68,8 +68,8 @@ public abstract class ChatListenerInternal {
     }
 
     protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final String messageContent, final @Nullable SignedMessage signedMessage, final ChatChannel channel) {
-        String content = this.configFactory.primaryConfig().applyChatPlaceholders(messageContent);
-        content = this.configFactory.primaryConfig().applyChatFilters(content);
+        String content = this.configManager.primaryConfig().applyChatPlaceholders(messageContent);
+        content = this.configManager.primaryConfig().applyChatFilters(content);
 
         final CarbonEarlyChatEvent earlyChatEvent = new CarbonEarlyChatEvent(sender, content);
         this.carbonEventHandler.emit(earlyChatEvent);

--- a/common/src/main/java/net/draycia/carbon/common/listeners/PingHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/PingHandler.java
@@ -26,7 +26,7 @@ import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.event.events.CarbonChatEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.util.KeyedRenderer;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
@@ -43,11 +43,11 @@ public class PingHandler implements Listener {
 
     private final Key pingKey = key("carbon", "pings");
     private final KeyedRenderer renderer;
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
 
     @Inject
-    public PingHandler(final CarbonEventHandler events, final ConfigFactory configFactory) {
-        this.configFactory = configFactory;
+    public PingHandler(final CarbonEventHandler events, final ConfigManager configManager) {
+        this.configManager = configManager;
         this.renderer = keyedRenderer(this.pingKey, (sender, recipient, message, originalMessage) -> {
             if (!(recipient instanceof CarbonPlayer recipientPlayer)) {
                 return message;
@@ -62,7 +62,7 @@ public class PingHandler implements Listener {
     }
 
     public Component convertPings(final CarbonPlayer recipient, final Component message) {
-        final String prefix = this.configFactory.primaryConfig().pings().prefix();
+        final String prefix = this.configManager.primaryConfig().pings().prefix();
         final String plainDisplayName = PlainTextComponentSerializer.plainText().serialize(recipient.displayName());
 
         return message.replaceText(TextReplacementConfig.builder()
@@ -75,11 +75,11 @@ public class PingHandler implements Listener {
                     Pattern.quote(plainDisplayName)),
                 Pattern.CASE_INSENSITIVE))
             .replacement(matchedText -> {
-                if (this.configFactory.primaryConfig().pings().playSound()) {
-                    recipient.playSound(this.configFactory.primaryConfig().pings().sound());
+                if (this.configManager.primaryConfig().pings().playSound()) {
+                    recipient.playSound(this.configManager.primaryConfig().pings().sound());
                 }
 
-                return Component.text(matchedText.content()).color(this.configFactory.primaryConfig().pings().highlightTextColor());
+                return Component.text(matchedText.content()).color(this.configManager.primaryConfig().pings().highlightTextColor());
             })
             .build());
     }

--- a/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSource.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSource.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -51,7 +50,7 @@ import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.DataDirectory;
 import net.draycia.carbon.common.command.PlayerCommander;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonReloadEvent;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.translation.Translator;
@@ -75,14 +74,14 @@ public final class CarbonMessageSource implements IMessageSource<Audience, Strin
     private CarbonMessageSource(
         final CarbonEventHandler events,
         final @DataDirectory Path dataDirectory,
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final Logger logger
     ) throws IOException {
         this.dataDirectory = dataDirectory;
         this.pluginJar = pluginJar();
         this.logger = logger;
 
-        this.defaultLocale = Objects.requireNonNull(configFactory.primaryConfig()).defaultLocale();
+        this.defaultLocale = configManager.primaryConfig().defaultLocale();
 
         this.reloadTranslations();
 

--- a/common/src/main/java/net/draycia/carbon/common/messaging/MessagingManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/MessagingManager.java
@@ -37,7 +37,7 @@ import net.draycia.carbon.api.CarbonServer;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.CarbonChatInternal;
 import net.draycia.carbon.common.command.commands.WhisperCommand;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.config.MessagingSettings;
 import net.draycia.carbon.common.messaging.packets.ChatMessagePacket;
 import net.draycia.carbon.common.messaging.packets.LocalPlayerChangePacket;
@@ -86,7 +86,7 @@ public class MessagingManager {
 
     @Inject
     public MessagingManager(
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final CarbonChat carbonChat,
         final @ServerId UUID serverId,
         final CarbonServer server,
@@ -98,7 +98,7 @@ public class MessagingManager {
     ) {
         this.serverId = serverId;
         this.logger = logger;
-        if (!configFactory.primaryConfig().messagingSettings().enabled()) {
+        if (!configManager.primaryConfig().messagingSettings().enabled()) {
             if (!((CarbonChatInternal) carbonChat).isProxy()) {
                 logger.info("Messaging services disabled in config. Cross-server will not work without this!");
             }
@@ -137,7 +137,7 @@ public class MessagingManager {
 
         try {
             this.initMessagingService(this.packetService, handlerImpl, new File("/"),
-                configFactory.primaryConfig().messagingSettings());
+                configManager.primaryConfig().messagingSettings());
         } catch (final IOException | TimeoutException | InterruptedException e) {
             e.printStackTrace();
             return;

--- a/common/src/main/java/net/draycia/carbon/common/users/CarbonPlayerCommon.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/CarbonPlayerCommon.java
@@ -34,7 +34,7 @@ import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.util.InventorySlot;
 import net.draycia.carbon.common.PlatformScheduler;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.identity.Identity;
@@ -53,7 +53,7 @@ public class CarbonPlayerCommon implements CarbonPlayer, ForwardingAudience.Sing
     private transient @MonotonicNonNull @Inject ChannelRegistry channelRegistry;
     private transient @MonotonicNonNull @Inject ProfileResolver profileResolver;
     private transient @MonotonicNonNull @Inject PlatformScheduler scheduler;
-    private transient @MonotonicNonNull @Inject ConfigFactory config;
+    private transient @MonotonicNonNull @Inject ConfigManager config;
     private volatile transient long transientLoadedSince = -1;
 
     protected final PersistentUserProperty<Boolean> muted;

--- a/common/src/main/java/net/draycia/carbon/common/users/db/mysql/MySQLUserManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/mysql/MySQLUserManager.java
@@ -30,7 +30,7 @@ import javax.sql.DataSource;
 import net.draycia.carbon.api.CarbonChat;
 import net.draycia.carbon.api.channels.ChannelRegistry;
 import net.draycia.carbon.api.channels.ChatChannel;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.config.DatabaseSettings;
 import net.draycia.carbon.common.messaging.MessagingManager;
 import net.draycia.carbon.common.messaging.packets.PacketFactory;
@@ -122,7 +122,7 @@ public final class MySQLUserManager extends DatabaseUserManager {
         @Inject
         private Factory(
             final ChannelRegistry channelRegistry,
-            final ConfigFactory configFactory,
+            final ConfigManager configManager,
             final Logger logger,
             final ProfileResolver profileResolver,
             final MembersInjector<CarbonPlayerCommon> playerInjector,
@@ -130,7 +130,7 @@ public final class MySQLUserManager extends DatabaseUserManager {
             final PacketFactory packetFactory
         ) {
             this.channelRegistry = channelRegistry;
-            this.databaseSettings = configFactory.primaryConfig().databaseSettings();
+            this.databaseSettings = configManager.primaryConfig().databaseSettings();
             this.logger = logger;
             this.profileResolver = profileResolver;
             this.playerInjector = playerInjector;

--- a/common/src/main/java/net/draycia/carbon/common/users/db/postgresql/PostgreSQLUserManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/postgresql/PostgreSQLUserManager.java
@@ -29,7 +29,7 @@ import javax.sql.DataSource;
 import net.draycia.carbon.api.CarbonChat;
 import net.draycia.carbon.api.channels.ChannelRegistry;
 import net.draycia.carbon.api.channels.ChatChannel;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.config.DatabaseSettings;
 import net.draycia.carbon.common.messaging.MessagingManager;
 import net.draycia.carbon.common.messaging.packets.PacketFactory;
@@ -123,7 +123,7 @@ public final class PostgreSQLUserManager extends DatabaseUserManager {
         @Inject
         private Factory(
             final ChannelRegistry channelRegistry,
-            final ConfigFactory configFactory,
+            final ConfigManager configManager,
             final Logger logger,
             final ProfileResolver profileResolver,
             final MembersInjector<CarbonPlayerCommon> playerInjector,
@@ -131,7 +131,7 @@ public final class PostgreSQLUserManager extends DatabaseUserManager {
             final PacketFactory packetFactory
         ) {
             this.channelRegistry = channelRegistry;
-            this.databaseSettings = configFactory.primaryConfig().databaseSettings();
+            this.databaseSettings = configManager.primaryConfig().databaseSettings();
             this.logger = logger;
             this.profileResolver = profileResolver;
             this.playerInjector = playerInjector;

--- a/common/src/main/java/net/draycia/carbon/common/util/CloudUtils.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/CloudUtils.java
@@ -57,8 +57,6 @@ import net.draycia.carbon.common.command.commands.UnmuteCommand;
 import net.draycia.carbon.common.command.commands.UpdateUsernameCommand;
 import net.draycia.carbon.common.command.commands.WhisperCommand;
 import net.draycia.carbon.common.command.exception.CommandCompleted;
-import net.draycia.carbon.common.config.CommandConfig;
-import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
@@ -102,16 +100,6 @@ public final class CloudUtils {
         }
 
         return settings;
-    }
-
-    public static Map<Key, CommandSettings> loadCommandSettings(final Injector injector) {
-        final @Nullable CommandConfig commandConfig = injector.getInstance(ConfigManager.class).loadCommandSettings();
-
-        if (commandConfig == null) {
-            return CloudUtils.defaultCommandSettings();
-        }
-
-        return commandConfig.settings();
     }
 
     public static void registerCommands(final Map<Key, CommandSettings> settings) {

--- a/common/src/main/java/net/draycia/carbon/common/util/CloudUtils.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/CloudUtils.java
@@ -58,7 +58,7 @@ import net.draycia.carbon.common.command.commands.UpdateUsernameCommand;
 import net.draycia.carbon.common.command.commands.WhisperCommand;
 import net.draycia.carbon.common.command.exception.CommandCompleted;
 import net.draycia.carbon.common.config.CommandConfig;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
@@ -105,7 +105,7 @@ public final class CloudUtils {
     }
 
     public static Map<Key, CommandSettings> loadCommandSettings(final Injector injector) {
-        final @Nullable CommandConfig commandConfig = injector.getInstance(ConfigFactory.class).loadCommandSettings();
+        final @Nullable CommandConfig commandConfig = injector.getInstance(ConfigManager.class).loadCommandSettings();
 
         if (commandConfig == null) {
             return CloudUtils.defaultCommandSettings();

--- a/fabric/src/main/java/net/draycia/carbon/fabric/FabricMessageRenderer.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/FabricMessageRenderer.java
@@ -25,7 +25,7 @@ import io.github.miniplaceholders.api.MiniPlaceholders;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Map;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessageRenderer;
 import net.draycia.carbon.common.messages.SourcedAudience;
 import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
@@ -43,11 +43,11 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 @Singleton
 public class FabricMessageRenderer implements CarbonMessageRenderer {
 
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
 
     @Inject
-    public FabricMessageRenderer(final ConfigFactory configFactory) {
-        this.configFactory = configFactory;
+    public FabricMessageRenderer(final ConfigManager configManager) {
+        this.configManager = configManager;
     }
 
     @Override
@@ -64,7 +64,7 @@ public class FabricMessageRenderer implements CarbonMessageRenderer {
             tagResolver.tag(entry.getKey(), Tag.inserting(entry.getValue()));
         }
 
-        final String placeholderResolvedMessage = this.configFactory.primaryConfig().applyCustomPlaceholders(intermediateMessage);
+        final String placeholderResolvedMessage = this.configManager.primaryConfig().applyCustomPlaceholders(intermediateMessage);
 
         if (FabricLoader.getInstance().isModLoaded("miniplaceholders")) {
             tagResolver.resolver(MiniPlaceholders.getGlobalPlaceholders());

--- a/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
@@ -21,7 +21,7 @@ package net.draycia.carbon.fabric.listeners;
 
 import com.google.inject.Inject;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
 import net.draycia.carbon.common.listeners.ChatListenerInternal;
 import net.draycia.carbon.common.messages.CarbonMessages;
@@ -44,11 +44,11 @@ public class FabricChatHandler extends ChatListenerInternal implements ServerMes
 
     @Inject
     public FabricChatHandler(
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final CarbonChatFabric carbonChat,
         final CarbonMessages carbonMessages
     ) {
-        super(carbonChat.eventHandler(), carbonMessages, configFactory);
+        super(carbonChat.eventHandler(), carbonMessages, configManager);
         this.carbonChat = carbonChat;
     }
 

--- a/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricJoinQuitListener.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricJoinQuitListener.java
@@ -22,7 +22,7 @@ package net.draycia.carbon.fabric.listeners;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.List;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messaging.MessagingManager;
 import net.draycia.carbon.common.messaging.packets.PacketFactory;
 import net.draycia.carbon.common.users.ProfileCache;
@@ -44,7 +44,7 @@ public class FabricJoinQuitListener implements ServerPlayConnectionEvents.Join, 
 
     private final ProfileCache profileCache;
     private final Logger logger;
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
     private final UserManagerInternal<?> userManager;
     private final Provider<MessagingManager> messaging;
     private final PacketFactory packetFactory;
@@ -52,14 +52,14 @@ public class FabricJoinQuitListener implements ServerPlayConnectionEvents.Join, 
     @Inject
     public FabricJoinQuitListener(
         final Logger logger,
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final ProfileCache profileCache,
         final UserManagerInternal<?> userManager,
         final Provider<MessagingManager> messaging,
         final PacketFactory packetFactory
     ) {
         this.logger = logger;
-        this.configFactory = configFactory;
+        this.configManager = configManager;
         this.profileCache = profileCache;
         this.userManager = userManager;
         this.messaging = messaging;
@@ -73,7 +73,7 @@ public class FabricJoinQuitListener implements ServerPlayConnectionEvents.Join, 
             packetService.queuePacket(this.packetFactory.addLocalPlayerPacket(handler.getPlayer().getUUID(), handler.getPlayer().getGameProfile().getName()));
         });
 
-        final @Nullable List<String> suggestions = this.configFactory.primaryConfig().customChatSuggestions();
+        final @Nullable List<String> suggestions = this.configManager.primaryConfig().customChatSuggestions();
 
         if (suggestions == null || suggestions.isEmpty()) {
             return;

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
@@ -32,7 +32,7 @@ import net.draycia.carbon.common.CarbonChatInternal;
 import net.draycia.carbon.common.PeriodicTasks;
 import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.draycia.carbon.common.command.ExecutionCoordinatorHolder;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.messaging.MessagingManager;
 import net.draycia.carbon.common.users.PlatformUserManager;
@@ -111,7 +111,7 @@ public final class CarbonChatPaper extends CarbonChatInternal {
         this.discoverDiscordHooks();
 
         final Metrics metrics = new Metrics(this.plugin, BSTATS_PLUGIN_ID);
-        metrics.addCustomChart(new SimplePie("user_manager_type", () -> this.injector().getInstance(ConfigFactory.class).primaryConfig().storageType().name()));
+        metrics.addCustomChart(new SimplePie("user_manager_type", () -> this.injector().getInstance(ConfigManager.class).primaryConfig().storageType().name()));
     }
 
     private void discoverDiscordHooks() {

--- a/paper/src/main/java/net/draycia/carbon/paper/command/DeleteMessageCommand.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/command/DeleteMessageCommand.java
@@ -32,7 +32,7 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.command.CarbonCommand;
 import net.draycia.carbon.common.command.CommandSettings;
 import net.draycia.carbon.common.command.Commander;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.key.Key;
@@ -49,7 +49,7 @@ public class DeleteMessageCommand extends CarbonCommand {
 
     final CarbonChat carbonChat;
     final CommandManager<Commander> commandManager;
-    final ConfigFactory configFactory;
+    final ConfigManager configManager;
     final CarbonMessages carbonMessages;
 
     final Cache<UUID, SignedMessage> signatureCache = Caffeine.newBuilder()
@@ -60,12 +60,12 @@ public class DeleteMessageCommand extends CarbonCommand {
     public DeleteMessageCommand(
         final CarbonChat carbonChat,
         final CommandManager<Commander> commandManager,
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final CarbonMessages carbonMessages
     ) {
         this.carbonChat = carbonChat;
         this.commandManager = commandManager;
-        this.configFactory = configFactory;
+        this.configManager = configManager;
         this.carbonMessages = carbonMessages;
     }
 

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
@@ -23,7 +23,7 @@ import com.google.inject.Inject;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.draycia.carbon.api.CarbonChat;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
 import net.draycia.carbon.common.listeners.ChatListenerInternal;
 import net.draycia.carbon.common.messages.CarbonMessages;
@@ -41,17 +41,17 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 public final class PaperChatListener extends ChatListenerInternal implements Listener {
 
     private final CarbonChat carbonChat;
-    final ConfigFactory configFactory;
+    final ConfigManager configManager;
 
     @Inject
     public PaperChatListener(
         final CarbonChat carbonChat,
         final CarbonMessages carbonMessages,
-        final ConfigFactory configFactory
+        final ConfigManager configManager
     ) {
-        super(carbonChat.eventHandler(), carbonMessages, configFactory);
+        super(carbonChat.eventHandler(), carbonMessages, configManager);
         this.carbonChat = carbonChat;
-        this.configFactory = configFactory;
+        this.configManager = configManager;
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperPlayerJoinListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperPlayerJoinListener.java
@@ -22,7 +22,7 @@ package net.draycia.carbon.paper.listeners;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.List;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messaging.MessagingManager;
 import net.draycia.carbon.common.messaging.packets.PacketFactory;
 import net.draycia.carbon.common.users.ProfileCache;
@@ -44,7 +44,7 @@ import static net.draycia.carbon.common.util.PlayerUtils.saveExceptionHandler;
 @DefaultQualifier(NonNull.class)
 public class PaperPlayerJoinListener implements Listener {
 
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
     private final Logger logger;
     private final ProfileCache profileCache;
     private final UserManagerInternal<?> userManager;
@@ -53,14 +53,14 @@ public class PaperPlayerJoinListener implements Listener {
 
     @Inject
     public PaperPlayerJoinListener(
-        final ConfigFactory configFactory,
+        final ConfigManager configManager,
         final Logger logger,
         final ProfileCache profileCache,
         final UserManagerInternal<?> userManager,
         final Provider<MessagingManager> messaging,
         final PacketFactory packetFactory
     ) {
-        this.configFactory = configFactory;
+        this.configManager = configManager;
         this.logger = logger;
         this.profileCache = profileCache;
         this.userManager = userManager;
@@ -84,7 +84,7 @@ public class PaperPlayerJoinListener implements Listener {
     public void onJoin(final PlayerJoinEvent event) {
         this.userManager.user(event.getPlayer().getUniqueId()).exceptionally(joinExceptionHandler(this.logger));
 
-        final @Nullable List<String> suggestions = this.configFactory.primaryConfig().customChatSuggestions();
+        final @Nullable List<String> suggestions = this.configManager.primaryConfig().customChatSuggestions();
 
         if (suggestions == null || suggestions.isEmpty()) {
             return;

--- a/paper/src/main/java/net/draycia/carbon/paper/messages/PaperMessageRenderer.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/messages/PaperMessageRenderer.java
@@ -28,7 +28,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.function.Supplier;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessageRenderer;
 import net.draycia.carbon.common.messages.SourcedAudience;
 import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
@@ -59,12 +59,12 @@ public class PaperMessageRenderer implements CarbonMessageRenderer {
     });
 
     private final MiniMessage miniMessage;
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
 
     @Inject
-    public PaperMessageRenderer(final ConfigFactory configFactory) {
+    public PaperMessageRenderer(final ConfigManager configManager) {
         this.miniMessage = MiniMessage.miniMessage();
-        this.configFactory = configFactory;
+        this.configManager = configManager;
     }
 
     @Override
@@ -81,7 +81,7 @@ public class PaperMessageRenderer implements CarbonMessageRenderer {
             tagResolver.tag(entry.getKey(), Tag.inserting(entry.getValue()));
         }
 
-        final String placeholderResolvedMessage = this.configFactory.primaryConfig().applyCustomPlaceholders(intermediateMessage);
+        final String placeholderResolvedMessage = this.configManager.primaryConfig().applyCustomPlaceholders(intermediateMessage);
 
         if (CarbonChatPaper.miniPlaceholdersLoaded()) {
             tagResolver.resolver(MiniPlaceholders.getGlobalPlaceholders());

--- a/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.util.InventorySlot;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.users.CarbonPlayerCommon;
 import net.draycia.carbon.common.users.WrappedCarbonPlayer;
 import net.draycia.carbon.common.util.EmptyAudienceWithPointers;
@@ -51,7 +51,7 @@ public final class CarbonPlayerPaper extends WrappedCarbonPlayer implements Forw
     @AssistedInject
     private CarbonPlayerPaper(
         final @Assisted CarbonPlayerCommon carbonPlayerCommon,
-        final ConfigFactory config
+        final ConfigManager config
     ) {
         super(carbonPlayerCommon);
 

--- a/velocity/src/main/java/net/draycia/carbon/velocity/CarbonVelocityBootstrap.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/CarbonVelocityBootstrap.java
@@ -28,7 +28,7 @@ import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import java.nio.file.Path;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.util.CarbonDependencies;
 import org.bstats.charts.SimplePie;
 import org.bstats.velocity.Metrics;
@@ -72,7 +72,7 @@ public final class CarbonVelocityBootstrap {
         this.injector.getInstance(CarbonChatVelocity.class).onInitialization(this);
 
         final Metrics metrics = this.metricsFactory.make(this, BSTATS_PLUGIN_ID);
-        metrics.addCustomChart(new SimplePie("user_manager_type", () -> this.injector.getInstance(ConfigFactory.class).primaryConfig().storageType().name()));
+        metrics.addCustomChart(new SimplePie("user_manager_type", () -> this.injector.getInstance(ConfigManager.class).primaryConfig().storageType().name()));
     }
 
     @Subscribe

--- a/velocity/src/main/java/net/draycia/carbon/velocity/VelocityMessageRenderer.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/VelocityMessageRenderer.java
@@ -26,7 +26,7 @@ import io.github.miniplaceholders.api.MiniPlaceholders;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Map;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessageRenderer;
 import net.draycia.carbon.common.messages.SourcedAudience;
 import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
@@ -43,12 +43,12 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 @Singleton
 public class VelocityMessageRenderer implements CarbonMessageRenderer {
 
-    private final ConfigFactory configFactory;
+    private final ConfigManager configManager;
     private final PluginManager pluginManager;
 
     @Inject
-    public VelocityMessageRenderer(final ConfigFactory configFactory, final PluginManager pluginManager) {
-        this.configFactory = configFactory;
+    public VelocityMessageRenderer(final ConfigManager configManager, final PluginManager pluginManager) {
+        this.configManager = configManager;
         this.pluginManager = pluginManager;
     }
 
@@ -66,7 +66,7 @@ public class VelocityMessageRenderer implements CarbonMessageRenderer {
             tagResolver.tag(entry.getKey(), Tag.inserting(entry.getValue()));
         }
 
-        final String placeholderResolvedMessage = this.configFactory.primaryConfig().applyCustomPlaceholders(intermediateMessage);
+        final String placeholderResolvedMessage = this.configManager.primaryConfig().applyCustomPlaceholders(intermediateMessage);
 
         if (this.pluginManager.isLoaded("miniplaceholders")) {
             tagResolver.resolver(MiniPlaceholders.getGlobalPlaceholders());

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
 import net.draycia.carbon.api.CarbonChat;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.users.UserManager;
-import net.draycia.carbon.common.config.ConfigFactory;
+import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
 import net.draycia.carbon.common.listeners.ChatListenerInternal;
 import net.draycia.carbon.common.messages.CarbonMessages;
@@ -51,7 +51,7 @@ public final class VelocityChatListener extends ChatListenerInternal implements 
     private final Logger logger;
     private final AtomicInteger timesWarned = new AtomicInteger(0);
     private final Supplier<Boolean> signedSupplier;
-    final ConfigFactory configFactory;
+    final ConfigManager configManager;
 
     @Inject
     private VelocityChatListener(
@@ -60,12 +60,12 @@ public final class VelocityChatListener extends ChatListenerInternal implements 
         final Logger logger,
         final PluginManager pluginManager,
         final CarbonMessages carbonMessages,
-        final ConfigFactory configFactory
+        final ConfigManager configManager
     ) {
-        super(carbonChat.eventHandler(), carbonMessages, configFactory);
+        super(carbonChat.eventHandler(), carbonMessages, configManager);
         this.userManager = userManager;
         this.logger = logger;
-        this.configFactory = configFactory;
+        this.configManager = configManager;
         this.signedSupplier = Suppliers.memoize(
             () -> pluginManager.isLoaded("unsignedvelocity")
                 || pluginManager.isLoaded("signedvelocity")


### PR DESCRIPTION
- ConfigFactory -> ConfigManager
- gracefully handle broken primary config on reload (continue using existing config and print error)
- throw error for broken primary config on init
- as a consequence of the previous two points #primaryConfig is no longer nullable
- write back configs after reading them, ensuring new config options get added to existing configs