### PR TITLE
Make message placeholders selfClosingInserting

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/command/commands/HelpCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/HelpCommand.java
@@ -125,8 +125,8 @@ public final class HelpCommand extends CarbonCommand {
             // Total hack but works for now
             if (args.length == 2) {
                 tagResolver
-                    .tag("page", Tag.inserting(text(args[0])))
-                    .tag("max_pages", Tag.inserting(text(args[1]))
+                    .tag("page", Tag.selfClosingInserting(text(args[0])))
+                    .tag("max_pages", Tag.selfClosingInserting(text(args[1]))
                 );
             }
 

--- a/common/src/main/java/net/draycia/carbon/common/config/ClearChatSettings.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/ClearChatSettings.java
@@ -60,8 +60,8 @@ public class ClearChatSettings {
     public Component broadcast(final Component displayName, final String username) {
         return MiniMessage.miniMessage().deserialize(this.broadcast,
             TagResolver.builder()
-                .tag("display_name", Tag.inserting(displayName))
-                .tag("username", Tag.inserting(Component.text(username)))
+                .tag("display_name", Tag.selfClosingInserting(displayName))
+                .tag("username", Tag.selfClosingInserting(Component.text(username)))
                 .build());
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/ComponentPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/ComponentPlaceholderResolver.java
@@ -44,7 +44,7 @@ public class ComponentPlaceholderResolver<R> implements IPlaceholderResolver<R, 
         final Method method,
         final @Nullable Object[] parameters
     ) {
-        return Map.of(placeholderName, Either.left(ConclusionValue.conclusionValue(Tag.inserting(value))));
+        return Map.of(placeholderName, Either.left(ConclusionValue.conclusionValue(Tag.selfClosingInserting(value))));
     }
 
 }


### PR DESCRIPTION
This fixes annoying things like `<display_name>` bleeding its format, but I have a feeling it will break some people's configs