### PR TITLE
fix: remove member from party before disbanding

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/command/commands/PartyCommands.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/PartyCommands.java
@@ -258,6 +258,7 @@ public final class PartyCommands extends CarbonCommand {
             this.messages.cannotDisbandParty(player, old.name());
             return;
         }
+        old.removeMember(player.uuid());
         old.disband();
         this.messages.disbandedParty(player, old.name());
     }


### PR DESCRIPTION
Otherwise, if a player leaves the party by disbanding, PartyLeaveEvent is not triggered.