### PR TITLE
Add helper for enabling/disabling third party plugins in run tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,4 @@ gradle-app.setting
 **/run/
 **/run2/
 
-**/run-plugins.properties
+**/run-plugins.yml

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ gradle-app.setting
 
 **/run/
 **/run2/
+
+**/run-plugins.properties

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation(libs.minotaur)
   implementation(libs.configurateYaml)
   implementation(libs.gremlin.gradle)
+  implementation(libs.run.task)
 
   implementation(libs.pluginYml)
   // Implementation dependencies of plugin-yml

--- a/build-logic/src/main/kotlin/ConfigurablePluginsExt.kt
+++ b/build-logic/src/main/kotlin/ConfigurablePluginsExt.kt
@@ -1,0 +1,24 @@
+import org.gradle.api.Action
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+
+abstract class ConfigurablePluginsExt {
+  data class DepPlugin(
+    val dep: Provider<MinimalExternalModuleDependency>,
+    val op: Action<in ExternalModuleDependency>?,
+    val defaultEnabled: Boolean = false,
+    val name: String = dep.get().name
+  )
+
+  abstract val gradleDependencyBased: ListProperty<DepPlugin>
+
+  fun dependency(lib: Provider<MinimalExternalModuleDependency>, op: Action<in ExternalModuleDependency>? = null) {
+    gradleDependencyBased.add(DepPlugin(lib, op))
+  }
+
+  fun dependency(lib: Provider<MinimalExternalModuleDependency>, defaultEnabled: Boolean, op: Action<in ExternalModuleDependency>? = null) {
+    gradleDependencyBased.add(DepPlugin(lib, op, defaultEnabled))
+  }
+}

--- a/build-logic/src/main/kotlin/carbon.configurable-plugins.gradle.kts
+++ b/build-logic/src/main/kotlin/carbon.configurable-plugins.gradle.kts
@@ -1,0 +1,54 @@
+import xyz.jpenilla.runtask.task.RunWithPlugins
+import java.util.Properties
+
+// todo use something better than properties for this (maybe configurate?)
+
+val ext = extensions.create("configurablePlugins", ConfigurablePluginsExt::class.java)
+
+val f = file("run-plugins.properties")
+fun props(): Properties {
+  val props = Properties()
+  if (f.isFile) {
+    f.bufferedReader().use { r -> props.load(r) }
+  }
+  return props
+}
+
+tasks.withType(RunWithPlugins::class).configureEach {
+  doFirst {
+    val props = props()
+    val text = f.takeIf { it.isFile }?.readText() ?: "\n"
+    val rest = text.substringAfter("# [taskName].[pluginName]=false")
+    fun prop(name: String, def: Any): String = "$name=${props[name] ?: def}"
+
+    val defProps = """
+    # Enable or disable plugins in run tasks
+
+    # applies to all run tasks in the project
+    ${ext.gradleDependencyBased.get().joinToString("\n") { prop(it.name, false) }}
+
+    # applies to only [taskName] (always has priority)
+    # [taskName].[pluginName]=false""".trimIndent() + rest
+
+    f.writeText(defProps)
+  }
+}
+
+afterEvaluate {
+  ext.gradleDependencyBased.get().forEach { entry ->
+    val c = configurations.register(entry.name + "Plugin") {
+      isTransitive = false
+    }
+    dependencies {
+      c.name(entry.dep) { entry.op?.execute(this) }
+    }
+    tasks.withType(RunWithPlugins::class).configureEach {
+      val props = props()
+      val prop = props["$name.${entry.name}"]
+        ?: props[entry.name]
+      if (prop.toString().toBoolean()) {
+        pluginJars.from(c)
+      }
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [plugins]
 sponge-gradle = { id = "org.spongepowered.gradle.plugin", version = "2.2.0" }
-runPaper = { id = "xyz.jpenilla.run-paper", version.ref = "runTask" }
-runVelocity = { id = "xyz.jpenilla.run-velocity", version.ref = "runTask" }
 hangar-publish = { id = "io.papermc.hangar-publish-plugin", version = "0.1.0" }
 indra-publishing-sonatype = { id = "net.kyori.indra.publishing.sonatype", version.ref = "indra" }
 
@@ -40,7 +38,7 @@ adventurePlatformFabric = "5.10.0"
 luckPermsApi = "5.4"
 essentialsx = "2.19.3"
 discordsrv = "1.26.0"
-placeholderapi = "2.10.9"
+placeholderapi = "2.11.5"
 miniplaceholders = "2.2.2"
 jdbi = "3.41.3"
 hikari = "5.1.0"
@@ -57,7 +55,7 @@ postgresql = "42.6.0"
 rabbitmq = "5.20.0"
 nats = "2.16.14"
 h2 = "2.2.224"
-towny = "0.100.0.0"
+towny = "0.100.0.2"
 
 [libraries]
 indraCommon = { group = "net.kyori", name = "indra-common", version.ref = "indra" }
@@ -66,6 +64,7 @@ shadow = { group = "com.github.johnrengelman", name = "shadow", version.ref = "s
 pluginYml = { group = "net.minecrell", name = "plugin-yml", version.ref = "pluginYml" }
 minotaur = { group = "com.modrinth.minotaur", name = "Minotaur", version.ref = "minotaur" }
 gremlin-gradle = { group = "xyz.jpenilla", name = "gremlin-gradle", version.ref = "gremlin" }
+run-task = { module = "xyz.jpenilla:run-task", version.ref = "runTask" }
 
 adventureBom = { group = "net.kyori", name = "adventure-bom", version.ref = "adventure" }
 adventureApi = { group = "net.kyori", name = "adventure-api" }

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -4,8 +4,9 @@ plugins {
   id("carbon.shadow-platform")
   id("net.minecrell.plugin-yml.bukkit")
   id("paper-plugin-yml")
-  alias(libs.plugins.runPaper)
+  id("xyz.jpenilla.run-paper")
   id("carbon.permissions")
+  id("carbon.configurable-plugins")
 }
 
 dependencies {
@@ -33,6 +34,8 @@ dependencies {
   }
 }
 
+configurablePlugins.dependency(libs.towny)
+
 tasks {
   shadowJar {
     relocateDependency("io.papermc.papertrail")
@@ -42,17 +45,15 @@ tasks {
   withType(RunServer::class).configureEach {
     version.set(libs.versions.minecraft)
     downloadPlugins {
-      url("https://download.luckperms.net/1515/bukkit/loader/LuckPerms-Bukkit-5.4.102.jar")
+      url("https://download.luckperms.net/1521/bukkit/loader/LuckPerms-Bukkit-5.4.108.jar")
       github("MiniPlaceholders", "MiniPlaceholders", libs.versions.miniplaceholders.get(), "MiniPlaceholders-Paper-${libs.versions.miniplaceholders.get()}.jar")
       github("MiniPlaceholders", "PlaceholderAPI-Expansion", "1.2.0", "PlaceholderAPI-Expansion-1.2.0.jar")
-      hangar("PlaceholderAPI", "2.11.5")
+      hangar("PlaceholderAPI", libs.versions.placeholderapi.get())
     }
   }
   register<RunServer>("runServer2") {
     pluginJars.from(shadowJar.flatMap { it.archiveFile })
     runDirectory.set(layout.projectDirectory.dir("run2"))
-  }
-  writeDependencies {
   }
 }
 

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -35,6 +35,7 @@ tasks {
     velocityVersion(libs.versions.velocityApi.get())
     downloadPlugins {
       url("https://download.luckperms.net/1521/velocity/LuckPerms-Velocity-5.4.108.jar")
+      github("MiniPlaceholders", "MiniPlaceholders", libs.versions.miniplaceholders.get(), "MiniPlaceholders-Velocity-${libs.versions.miniplaceholders.get()}.jar")
     }
   }
   processResources {

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("carbon.shadow-platform")
-  alias(libs.plugins.runVelocity)
+  id("xyz.jpenilla.run-velocity")
 }
 
 dependencies {
@@ -34,7 +34,7 @@ tasks {
   runVelocity {
     velocityVersion(libs.versions.velocityApi.get())
     downloadPlugins {
-      url("https://download.luckperms.net/1515/velocity/LuckPerms-Velocity-5.4.102.jar")
+      url("https://download.luckperms.net/1521/velocity/LuckPerms-Velocity-5.4.108.jar")
     }
   }
   processResources {


### PR DESCRIPTION
Writes a `$projectDir/run-plugins.yml` like this on run tasks

```yml
# Enable and disable optional plugins for run tasks in this project

defaults:
    towny: false
task-overrides:
    someTaskName:
        somePlugin: false

```

Only implemented for dependency-based plugins, not run-task downloadPlugins plugins, although it could be expanded in the future if the need arises