### PR TITLE
Removed UnSignedVelocity metadata references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ hangarPublish.publications.register("plugin") {
       hangar("MiniPlaceholders") {
         required.set(false)
       }
-      hangar("UnSignedVelocity") {
+      hangar("SignedVelocity") {
         required.set(false)
       }
     }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -52,7 +52,7 @@ tasks {
 publishMods.modrinth {
   modLoaders.addAll("velocity")
   optional {
-    slug = "unsignedvelocity"
+    slug = "signedvelocity"
   }
 }
 

--- a/velocity/src/main/resources/velocity-plugin.json
+++ b/velocity/src/main/resources/velocity-plugin.json
@@ -18,7 +18,7 @@
             "optional": true
         },
         {
-            "id": "unsignedvelocity",
+            "id": "signedvelocity",
             "optional": true
         }
     ],


### PR DESCRIPTION
_The UnSignedVelocity check in the ChatListener can still be retained as almost 300 networks are still using UnSignedVelocity despite its ineffectiveness_