### PR TITLE
feat: legacy ampersand

### DIFF
--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -62,7 +62,7 @@ tasks {
   withType(RunServer::class).configureEach {
     version.set(libs.versions.minecraft)
     downloadPlugins {
-      url("https://download.luckperms.net/1533/bukkit/loader/LuckPerms-Bukkit-5.4.120.jar")
+      url("https://download.luckperms.net/1543/bukkit/loader/LuckPerms-Bukkit-5.4.130.jar")
       github("MiniPlaceholders", "MiniPlaceholders", libs.versions.miniplaceholders.get(), "MiniPlaceholders-Paper-${libs.versions.miniplaceholders.get()}.jar")
       github("MiniPlaceholders", "PlaceholderAPI-Expansion", "1.2.0", "PlaceholderAPI-Expansion-1.2.0.jar")
       hangar("PlaceholderAPI", libs.versions.placeholderapi.get())

--- a/paper/src/main/java/net/draycia/carbon/paper/messages/PlaceholderAPIMiniMessageParser.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/messages/PlaceholderAPIMiniMessageParser.java
@@ -49,12 +49,17 @@ public final class PlaceholderAPIMiniMessageParser {
     private static boolean containsLegacyColorCodes(final String string) {
         final char[] charArray = string.toCharArray();
         for (int i = 0; i < charArray.length - 1; i++) {
-            if (charArray[i] == LegacyComponentSerializer.SECTION_CHAR
+            if ((charArray[i] == LegacyComponentSerializer.SECTION_CHAR ||
+                charArray[i] == LegacyComponentSerializer.AMPERSAND_CHAR)
                 && "0123456789AaBbCcDdEeFfKkLlMmNnOoRrXx".indexOf(charArray[i + 1]) > -1) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static String replaceAmpersandWithSectionSymbol(final String string) {
+        return string.replace('&', '§');
     }
 
     public Component parse(final OfflinePlayer player, final String input, final TagResolver tagResolver) {
@@ -103,7 +108,7 @@ public final class PlaceholderAPIMiniMessageParser {
             } else {
                 final String key = "papi_generated_template_" + id;
                 id++;
-                tagResolver.tag(key, Tag.inserting(LegacyComponentSerializer.legacySection().deserialize(replaced)));
+                tagResolver.tag(key, Tag.inserting(LegacyComponentSerializer.legacySection().deserialize(replaceAmpersandWithSectionSymbol(replaced))));
                 matcher.appendReplacement(builder, Matcher.quoteReplacement("<" + key + ">"));
             }
         }


### PR DESCRIPTION
I did a proof of concept replacement of our cross-server chat plugin on our network, after which noticing a fair few placeholder values are still using `&` legacy symbol, so I've made a quick and dirty change to replace ampersand symbol with the section symbol to allow this to parse - there probably is a cleaner solution, but seems unnecessary to call both `legacySection` and `legacyAmpersand`.

Also updated the LuckPerms link as it was outdated when I attempted to run the server