### PR TITLE
Allow disabling cross-server broadcasting per-channel

### DIFF
--- a/api/src/main/java/net/draycia/carbon/api/channels/ChatChannel.java
+++ b/api/src/main/java/net/draycia/carbon/api/channels/ChatChannel.java
@@ -132,4 +132,12 @@ public interface ChatChannel extends Keyed, ChatComponentRenderer {
      */
     long startCooldown(CarbonPlayer player);
 
+    /**
+     * Whether messages from this channel should be broadcast and sent to other servers.
+     *
+     * @return if this channel's messages should be sent cross-server
+     * @since 3.0.0
+     */
+    boolean shouldCrossServer();
+
 }

--- a/common/src/main/java/net/draycia/carbon/common/channels/ConfigChatChannel.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/ConfigChatChannel.java
@@ -117,6 +117,9 @@ public class ConfigChatChannel implements ChatChannel {
 
     private long cooldown = -1;
 
+    @Comment("Whether this channel's messages should be sent cross-server.")
+    private boolean crossServer = true;
+
     @Override
     public @Nullable String quickPrefix() {
         if (this.quickPrefix == null || this.quickPrefix.isBlank()) {
@@ -261,6 +264,11 @@ public class ConfigChatChannel implements ChatChannel {
     @Override
     public boolean emptyRadiusRecipientsMessage() {
         return this.emptyRadiusRecipientsMessage;
+    }
+
+    @Override
+    public boolean shouldCrossServer() {
+        return this.crossServer;
     }
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/listeners/MessagePacketHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/MessagePacketHandler.java
@@ -51,6 +51,10 @@ public class MessagePacketHandler implements Listener {
                 return;
             }
 
+            if (!event.chatChannel().shouldCrossServer()) {
+                return;
+            }
+
             messaging.get().queuePacket(() -> {
                 final CarbonPlayer sender = event.sender();
                 final Component networkMessage = e.renderFor(sender);

--- a/common/src/main/java/net/draycia/carbon/common/messaging/CarbonChatPacketHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/CarbonChatPacketHandler.java
@@ -122,6 +122,10 @@ public final class CarbonChatPacketHandler extends AbstractMessagingHandler {
             return false;
         }
 
+        if (!channel.shouldCrossServer()) {
+            return false;
+        }
+
         final List<KeyedRenderer> renderers = new ArrayList<>();
 
         final List<Audience> recipients = channel.recipients(sender);

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/AbstractFactionsChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/AbstractFactionsChannel.java
@@ -48,4 +48,9 @@ abstract class AbstractFactionsChannel extends ConfigChatChannel {
         return faction != null && faction.getRelationCount(relation) > 0;
     }
 
+    @Override
+    public boolean shouldCrossServer() {
+        return false;
+    }
+
 }

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoPartyChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoPartyChannel.java
@@ -101,4 +101,9 @@ public class McmmoPartyChannel extends ConfigChatChannel {
         return PartyManager.getParty(Bukkit.getPlayer(player.uuid()));
     }
 
+    @Override
+    public boolean shouldCrossServer() {
+        return false;
+    }
+
 }

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/towny/ResidentListChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/towny/ResidentListChannel.java
@@ -91,4 +91,9 @@ abstract class ResidentListChannel<T extends ResidentList> extends ConfigChatCha
 
     protected abstract Component cannotUseChannel(CarbonPlayer player);
 
+    @Override
+    public boolean shouldCrossServer() {
+        return false;
+    }
+
 }


### PR DESCRIPTION
Closes #535

- [x] Block outgoing messages when `cross-server` is false
- [x] Block incoming messages when `cross-server` is false