### PR TITLE
Fix console logs having spy prefix

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/listeners/MuteHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/MuteHandler.java
@@ -25,6 +25,7 @@ import net.draycia.carbon.api.event.events.CarbonChatEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.util.KeyedRenderer;
 import net.draycia.carbon.common.messages.CarbonMessages;
+import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
@@ -58,7 +59,7 @@ public class MuteHandler implements Listener {
             event.renderers().add(this.renderer);
 
             event.recipients().removeIf(entry -> entry instanceof CarbonPlayer carbonPlayer &&
-                !carbonPlayer.spying());
+                !carbonPlayer.spying() && !(entry instanceof ConsoleCarbonPlayer));
         });
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/users/ConsoleCarbonPlayer.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/ConsoleCarbonPlayer.java
@@ -185,7 +185,7 @@ public class ConsoleCarbonPlayer implements CarbonPlayer, ForwardingAudience.Sin
 
     @Override
     public boolean spying() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Console should see all messages, the prefix is redundant