### PR TITLE
Fix PostgreSQL migrations V9 and V10

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -75,6 +75,6 @@ jobs:
       - name: Smoke test (Paper, MariaDB)
         run: ./gradlew :carbonchat-paper:runServer -PsmokeTest=true -PsmokeTestMode=mariadb
         timeout-minutes: 5
-      #- name: Smoke test (Paper, Postgres)
-      #  run: ./gradlew :carbonchat-paper:runServer -PsmokeTest=true -PsmokeTestMode=postgres
-      #  timeout-minutes: 5
+      - name: Smoke test (Paper, Postgres)
+        run: ./gradlew :carbonchat-paper:runServer -PsmokeTest=true -PsmokeTestMode=postgres
+        timeout-minutes: 5

--- a/common/src/main/resources/queries/migrations/postgresql/V10__tempmute.sql
+++ b/common/src/main/resources/queries/migrations/postgresql/V10__tempmute.sql
@@ -1,1 +1,1 @@
-ALTER TABLE carbon_users ALTER COLUMN muteexpiration TYPE BIGINT;
+ALTER TABLE carbon_users ALTER COLUMN muteexpiration TYPE BIGINT USING (CASE WHEN muteexpiration THEN 1 ELSE 0 END);

--- a/common/src/main/resources/queries/migrations/postgresql/V9__tempmute.sql
+++ b/common/src/main/resources/queries/migrations/postgresql/V9__tempmute.sql
@@ -1,1 +1,1 @@
-ALTER TABLE carbon_users ADD COLUMN muteexpiration BOOLEAN AFTER muted;
+ALTER TABLE carbon_users ADD COLUMN muteexpiration BOOLEAN;


### PR DESCRIPTION
PostgreSQL doesn't care about column order, so V9 needs `AFTER muted` to be removed.

PostgreSQL won't cast directly from a `BOOL` to `BIGINT`, so it needs explicit logic on how to cast.

fixes #652