### PR TITLE
Add smoke test for SQL migrations and Paper startup

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -1,0 +1,68 @@
+name: Smoke test
+on:
+  workflow_run:
+    workflows: ["Build"]  # This should match the exact name in build.yml
+    types:
+      - completed
+
+jobs:
+  check:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: username
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: carbon
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mariadb:
+        image: mariadb:10.5
+        env:
+          MARIADB_USER: username
+          MARIADB_PASSWORD: password
+          MARIADB_ROOT_PASSWORD: rootpassword
+          MARIADB_DATABASE: carbon
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    strategy:
+      matrix:
+        java: [ 21 ]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4
+      - name: JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        # gradle build action can't handle project dir local caches
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .gradle/loom-cache
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/libs.versions.*', '**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Smoke test (Paper, Postgres)
+        run: ./gradlew :carbonchat-paper:runServer -PsmokeTest=true -PsmokeTestMode=postgres
+      - name: Smoke test (Paper, MariaDB)
+        run: ./gradlew :carbonchat-paper:runServer -PsmokeTest=true -PsmokeTestMode=mariadb
+      - name: Smoke test (Paper, H2)
+        run: ./gradlew :carbonchat-paper:runServer -PsmokeTest=true -PsmokeTestMode=h2
+      - name: Smoke test (Paper, JSON)
+        run: ./gradlew :carbonchat-paper:runServer -PsmokeTest=true -PsmokeTestMode=json

--- a/common/src/main/java/net/draycia/carbon/common/CarbonCommonModule.java
+++ b/common/src/main/java/net/draycia/carbon/common/CarbonCommonModule.java
@@ -67,6 +67,7 @@ import net.draycia.carbon.common.command.commands.UpdateUsernameCommand;
 import net.draycia.carbon.common.command.commands.WhisperCommand;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.config.DatabaseSettings;
+import net.draycia.carbon.common.config.PrimaryConfig;
 import net.draycia.carbon.common.event.CarbonEventHandlerImpl;
 import net.draycia.carbon.common.listeners.DeafenHandler;
 import net.draycia.carbon.common.listeners.FilterHandler;
@@ -136,9 +137,23 @@ public final class CarbonCommonModule extends AbstractModule {
         final Logger logger,
         final Injector injector
     ) throws IOException {
-        logger.info("Initializing " + configManager.primaryConfig().storageType() + " storage manager...");
+        PrimaryConfig.StorageType storageType = configManager.primaryConfig().storageType();
 
-        return switch (configManager.primaryConfig().storageType()) {
+        final String smokeTestMode = System.getProperty("carbonchat.smokeTestMode");
+        if (smokeTestMode != null) {
+            logger.info("Smoke test: Overriding storage manager.");
+            switch (smokeTestMode) {
+                case "h2" -> storageType = PrimaryConfig.StorageType.H2;
+                case "json" -> storageType = PrimaryConfig.StorageType.JSON;
+                case "postgres" -> storageType = PrimaryConfig.StorageType.PSQL;
+                case "mariadb" -> storageType = PrimaryConfig.StorageType.MYSQL;
+                default -> throw new IllegalArgumentException("Unknown smoke test mode: " + smokeTestMode);
+            }
+        }
+
+        logger.info("Initializing {} storage manager...", storageType);
+
+        return switch (storageType) {
             case MYSQL -> injector.getInstance(DatabaseUserManager.Factory.class).create(
                 "queries/migrations/mysql",
                 jdbi -> jdbi.registerArgument(new BinaryUUIDArgumentFactory())

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -66,6 +66,23 @@ tasks {
       github("MiniPlaceholders", "PlaceholderAPI-Expansion", "1.2.0", "PlaceholderAPI-Expansion-1.2.0.jar")
       hangar("PlaceholderAPI", libs.versions.placeholderapi.get())
     }
+    providers.gradleProperty("smokeTest").map { it.toBoolean() }.getOrElse(false).let { smokeTest ->
+      if (smokeTest) {
+        runDirectory.set(layout.buildDirectory.dir("tmp/smokeTest"))
+        doFirst {
+          runDirectory.get().file("carbonchat-smoketest").asFile.takeIf { it.exists() }?.delete()
+          runDirectory.get().file("eula.txt").asFile.also { it.parentFile.mkdirs() }.writeText("eula=true")
+        }
+        doLast {
+          val pass = runDirectory.get().file("carbonchat-smoketest").asFile.exists()
+          if (!pass) {
+            throw GradleException("Smoke test failed, please check the logs.")
+          }
+        }
+        systemProperty("carbonchat.smokeTest", true)
+        systemProperty("carbonchat.smokeTestMode", providers.gradleProperty("smokeTestMode").getOrElse("h2"))
+      }
+    }
   }
   register<RunServer>("runServer2") {
     pluginJars.from(shadowJar.flatMap { it.archiveFile })

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
@@ -25,6 +25,8 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
+import java.io.File;
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import net.draycia.carbon.api.CarbonServer;
@@ -116,6 +118,19 @@ public final class CarbonChatPaper extends CarbonChatInternal {
         }));
 
         this.checkVersion();
+
+        if (Boolean.getBoolean("carbonchat.smokeTest")) {
+            this.logger().info("Smoke test: CarbonChat successfully enabled.");
+            try {
+                new File("carbonchat-smoketest").createNewFile();
+            } catch (final IOException e) {
+                this.logger().error("Smoke test: Failed to create file.", e);
+            }
+            this.plugin.getServer().getScheduler().runTaskLater(this.plugin, () -> {
+                this.logger().info("Smoke test: Shutting down server.");
+                Bukkit.getServer().shutdown();
+            }, 20L);
+        }
     }
 
     private void registerPlaceholders() {


### PR DESCRIPTION
In the future we may want to use a matrix and test other platforms

related: #652, #653