### PR TITLE
Split component rendering into pre/post stages

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
@@ -54,6 +54,7 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
+import net.draycia.carbon.common.event.events.CarbonEarlyChatEvent;
 import net.draycia.carbon.common.event.events.CarbonReloadEvent;
 import net.draycia.carbon.common.event.events.ChannelRegisterEventImpl;
 import net.draycia.carbon.common.event.events.ChannelSwitchEventImpl;
@@ -65,6 +66,7 @@ import net.draycia.carbon.common.util.FileUtil;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.ChatType;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -344,7 +346,15 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
         final ChatChannel channel,
         final SignedString message
     ) {
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message.string(), message.signedMessage(), channel);
+        final Component originalMessage = Objects.requireNonNullElse(message.signedMessage().unsignedContent(), Component.text(message.signedMessage().message()));
+        final @Nullable CarbonEarlyChatEvent earlyChatEvent = this.prepareAndEmitPreChatEvent(sender, originalMessage);
+
+        if (earlyChatEvent == null || earlyChatEvent.cancelled()) {
+            return;
+        }
+
+        final @Nullable Component parsedMessage = this.parseTags(sender, earlyChatEvent.message());
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, parsedMessage, message.signedMessage(), channel);
 
         if (chatEvent == null || chatEvent.cancelled()) {
             return;

--- a/common/src/main/java/net/draycia/carbon/common/event/events/CarbonEarlyChatEvent.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/CarbonEarlyChatEvent.java
@@ -19,13 +19,15 @@
  */
 package net.draycia.carbon.common.event.events;
 
+import net.draycia.carbon.api.event.Cancellable;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 
-public class CarbonEarlyChatEvent implements CarbonEvent {
+public class CarbonEarlyChatEvent implements CarbonEvent, Cancellable {
 
-    public final CarbonPlayer sender;
-    public String message;
+    private final CarbonPlayer sender;
+    private String message;
+    private boolean cancelled = false;
 
     public CarbonEarlyChatEvent(final CarbonPlayer sender, final String message) {
         this.sender = sender;
@@ -42,6 +44,16 @@ public class CarbonEarlyChatEvent implements CarbonEvent {
 
     public void message(final String message) {
         this.message = message;
+    }
+
+    @Override
+    public boolean cancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void cancelled(final boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
 }

--- a/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
@@ -61,21 +61,14 @@ public abstract class ChatListenerInternal {
         this.carbonEventHandler = carbonEventHandler;
     }
 
-    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final String messageContent, final @Nullable SignedMessage signedMessage) {
-        final CarbonPlayer.ChannelMessage channelMessage = sender.channelForMessage(Component.text(messageContent));
+    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final Component originalMessage, final @Nullable SignedMessage signedMessage) {
+        final CarbonPlayer.ChannelMessage channelMessage = sender.channelForMessage(originalMessage);
         final ChatChannel channel = channelMessage.channel();
-        final String message = PlainTextComponentSerializer.plainText().serialize(channelMessage.message());
 
-        return this.prepareAndEmitChatEvent(sender, message, signedMessage, channel);
+        return this.prepareAndEmitChatEvent(sender, channelMessage.message(), signedMessage, channel);
     }
 
-    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final String messageContent, final @Nullable SignedMessage signedMessage, final ChatChannel channel) {
-        final ChannelPermissionResult permitted = channel.permissions().speechPermitted(sender);
-        if (!permitted.permitted()) {
-            sender.sendMessage(permitted.reason());
-            return null;
-        }
-
+    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final Component message, final @Nullable SignedMessage signedMessage, final ChatChannel channel) {
         if (!sender.hasPermission("carbon.cooldown.exempt") && channel.cooldown() > 0) {
             final long currentMillis = System.currentTimeMillis();
             final long expiresAt = channel.playerCooldown(sender);
@@ -88,24 +81,6 @@ public abstract class ChatListenerInternal {
             }
 
             channel.startCooldown(sender);
-        }
-        
-        String content = this.configManager.primaryConfig().applyChatPlaceholders(messageContent);
-
-        final CarbonEarlyChatEvent earlyChatEvent = new CarbonEarlyChatEvent(sender, content);
-        this.carbonEventHandler.emit(earlyChatEvent);
-
-        content = earlyChatEvent.message();
-
-        final Component message;
-
-        if (sender instanceof WrappedCarbonPlayer wrapped) {
-            message = wrapped.parseMessageTags(content);
-        } else {
-            message = TagPermissions.parseTags(sender, TagPermissions.MESSAGE, content, sender::hasPermission);
-        }
-        if (probablyBlank(message)) {
-            return null;
         }
 
         if (sender.leftChannels().contains(channel.key())) {
@@ -123,6 +98,41 @@ public abstract class ChatListenerInternal {
         this.carbonEventHandler.emit(chatEvent);
 
         return chatEvent;
+    }
+
+    protected @Nullable CarbonEarlyChatEvent prepareAndEmitPreChatEvent(final CarbonPlayer sender, final Component originalMessage) {
+        final CarbonPlayer.ChannelMessage channelMessage = sender.channelForMessage(originalMessage);
+        final ChatChannel channel = channelMessage.channel();
+
+        final ChannelPermissionResult permitted = channel.permissions().speechPermitted(sender);
+        if (!permitted.permitted()) {
+            sender.sendMessage(permitted.reason());
+            return null;
+        }
+
+        final String plainContent = PlainTextComponentSerializer.plainText().serialize(channelMessage.message());
+        final String content = this.configManager.primaryConfig().applyChatPlaceholders(plainContent);
+
+        final CarbonEarlyChatEvent earlyChatEvent = new CarbonEarlyChatEvent(sender, content);
+        this.carbonEventHandler.emit(earlyChatEvent);
+
+        return earlyChatEvent;
+    }
+
+    protected @Nullable Component parseTags(final CarbonPlayer sender, final String format) {
+        final Component message;
+
+        if (sender instanceof WrappedCarbonPlayer wrapped) {
+            message = wrapped.parseMessageTags(format);
+        } else {
+            message = TagPermissions.parseTags(sender, TagPermissions.MESSAGE, format, sender::hasPermission);
+        }
+
+        if (probablyBlank(message)) {
+            return null;
+        }
+
+        return message;
     }
 
     private static boolean probablyBlank(final Component component) {

--- a/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
@@ -20,14 +20,17 @@
 package net.draycia.carbon.fabric.listeners;
 
 import com.google.inject.Inject;
+import java.util.Objects;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
+import net.draycia.carbon.common.event.events.CarbonEarlyChatEvent;
 import net.draycia.carbon.common.listeners.ChatListenerInternal;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.fabric.CarbonChatFabric;
 import net.draycia.carbon.fabric.users.CarbonPlayerFabric;
 import net.fabricmc.fabric.api.message.v1.ServerMessageEvents;
+import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
 import net.kyori.adventure.text.Component;
 import net.minecraft.commands.CommandSourceStack;
@@ -69,8 +72,18 @@ public class FabricChatHandler extends ChatListenerInternal implements ServerMes
 
         final @Nullable CarbonPlayer sender = this.carbonChat.userManager().user(serverPlayer.getUUID()).join();
 
-        final String content = chatMessage.decoratedContent().getString();
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, content, null);
+        final MinecraftServerAudiences audiences = MinecraftServerAudiences.of(serverPlayer.level().getServer());
+        final SignedMessage signedMessage = audiences.asAdventure(chatMessage);
+        final Component originalMessage = Objects.requireNonNullElse(signedMessage.unsignedContent(), Component.text(signedMessage.message()));
+
+        final @Nullable CarbonEarlyChatEvent earlyChatEvent = this.prepareAndEmitPreChatEvent(sender, originalMessage);
+
+        if (earlyChatEvent == null || earlyChatEvent.cancelled()) {
+            return false;
+        }
+
+        final @Nullable Component message = this.parseTags(sender, earlyChatEvent.message());
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, audiences.asAdventure(chatMessage));
 
         if (chatEvent == null || chatEvent.cancelled()) {
             return false;
@@ -79,7 +92,7 @@ public class FabricChatHandler extends ChatListenerInternal implements ServerMes
         for (final var recipient : chatEvent.recipients()) {
             final Component finishedMessage = chatEvent.renderFor(recipient);
 
-            final net.minecraft.network.chat.Component nativeMessage = MinecraftServerAudiences.of(serverPlayer.level().getServer()).nonWrappingSerializer().serialize(finishedMessage);
+            final net.minecraft.network.chat.Component nativeMessage = audiences.nonWrappingSerializer().serialize(finishedMessage);
             final PlayerChatMessage customChatMessage = new PlayerChatMessage(chatMessage.link(), chatMessage.signature(), chatMessage.signedBody(), nativeMessage, FilterMask.FULLY_FILTERED);
             final RegistryAccess registryAccess = serverPlayer.level().registryAccess();
             if (this.chatTypeResourceKey == null) {

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
@@ -20,16 +20,19 @@
 package net.draycia.carbon.paper.listeners;
 
 import com.google.inject.Inject;
+import io.papermc.paper.event.player.AsyncChatCommandDecorateEvent;
+import io.papermc.paper.event.player.AsyncChatDecorateEvent;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.draycia.carbon.api.CarbonChat;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
+import net.draycia.carbon.common.event.events.CarbonEarlyChatEvent;
 import net.draycia.carbon.common.listeners.ChatListenerInternal;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
-import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.kyori.adventure.text.Component;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -54,6 +57,34 @@ public final class PaperChatListener extends ChatListenerInternal implements Lis
         this.configManager = configManager;
     }
 
+    @SuppressWarnings("UnstableApiUsage")
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onPaperChatDecorate(final @NonNull AsyncChatDecorateEvent event) {
+        if (event.player() == null) {
+            return;
+        }
+
+        final @Nullable CarbonPlayer sender = this.carbonChat.userManager().user(event.player().getUniqueId()).join();
+        final @Nullable CarbonEarlyChatEvent earlyChatEvent = this.prepareAndEmitPreChatEvent(sender, event.result());
+
+        if (earlyChatEvent == null || earlyChatEvent.cancelled()) {
+            event.setCancelled(true);
+            return;
+        }
+
+        final @Nullable Component message = this.parseTags(sender, earlyChatEvent.message());
+
+        if (message != null) {
+            event.result(message);
+        }
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
+    public void onPaperCommandDecorate(final @NonNull AsyncChatCommandDecorateEvent event) {
+        this.onPaperChatDecorate(event);
+    }
+
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onPaperChat(final @NonNull AsyncChatEvent event) {
         final @Nullable CarbonPlayer sender = this.carbonChat.userManager().user(event.getPlayer().getUniqueId()).join();
@@ -62,8 +93,7 @@ public final class PaperChatListener extends ChatListenerInternal implements Lis
             return;
         }
 
-        final String content = PlainTextComponentSerializer.plainText().serialize(event.message());
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, content, event.signedMessage());
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, event.message(), event.signedMessage());
 
         if (chatEvent == null || chatEvent.cancelled()) {
             event.setCancelled(true);

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
@@ -35,10 +35,12 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.users.UserManager;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.event.events.CarbonChatEventImpl;
+import net.draycia.carbon.common.event.events.CarbonEarlyChatEvent;
 import net.draycia.carbon.common.listeners.ChatListenerInternal;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.velocity.CarbonVelocityBootstrap;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -111,9 +113,14 @@ public final class VelocityChatListener extends ChatListenerInternal implements 
         event.setResult(PlayerChatEvent.ChatResult.denied());
 
         final CarbonPlayer sender = this.userManager.user(event.getPlayer().getUniqueId()).join();
+        final @Nullable CarbonEarlyChatEvent earlyChatEvent = this.prepareAndEmitPreChatEvent(sender, Component.text(event.getMessage()));
 
-        final String content = event.getResult().getMessage().orElse(event.getMessage());
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, content, null);
+        if (earlyChatEvent == null || earlyChatEvent.cancelled()) {
+            return;
+        }
+
+        final @Nullable Component message = this.parseTags(sender, earlyChatEvent.message());
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, null);
 
         if (chatEvent == null || chatEvent.cancelled()) {
             return;


### PR DESCRIPTION
Allows modification of the chat message before it's formatted / used in platform events
Closes #647 