### PR TITLE
Patch disconnect error with messaging system

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayerChangePacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayerChangePacket.java
@@ -52,6 +52,14 @@ public final class LocalPlayerChangePacket extends CarbonPacket {
         this.changeType = changeType;
     }
 
+    @AssistedInject
+    public LocalPlayerChangePacket(final @ServerId UUID serverId, final @Assisted UUID playerId) {
+        super(serverId);
+        this.playerId = playerId;
+        this.playerName = null;
+        this.changeType = ChangeType.REMOVE;
+    }
+
     public LocalPlayerChangePacket(final UUID sender, final ByteBuf data) {
         super(sender);
         this.read(data);

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/PacketFactory.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/PacketFactory.java
@@ -45,9 +45,7 @@ public interface PacketFactory {
         return this.localPlayerChangePacket(id, name, LocalPlayerChangePacket.ChangeType.ADD);
     }
 
-    default LocalPlayerChangePacket removeLocalPlayerPacket(final UUID id) {
-        return this.localPlayerChangePacket(id, null, LocalPlayerChangePacket.ChangeType.REMOVE);
-    }
+    LocalPlayerChangePacket removeLocalPlayerPacket(final UUID id);
 
     WhisperPacket whisperPacket(@Assisted("from") UUID from, @Assisted("to") UUID to, Component msg);
 


### PR DESCRIPTION
Prevents the error by not supplying a null value to begin with, but doesn't fix the fact that guice is throwing null when default factory methods invoke generated ones, despite there being appropriate Nullable annotations. 

Closes #727 