### PR TITLE
fix: guard null signed command messages in channel registry

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
@@ -65,6 +65,7 @@ import net.draycia.carbon.common.util.Exceptions;
 import net.draycia.carbon.common.util.FileUtil;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
@@ -346,15 +347,30 @@ public class CarbonChannelRegistry extends ChatListenerInternal implements Chann
         final ChatChannel channel,
         final SignedString message
     ) {
-        final Component originalMessage = Objects.requireNonNullElse(message.signedMessage().unsignedContent(), Component.text(message.signedMessage().message()));
+        final @Nullable SignedMessage signedMessage = message.signedMessage();
+        final Component originalMessage;
+
+        if (signedMessage == null) {
+            originalMessage = Component.text(message.string());
+        } else {
+            originalMessage = Objects.requireNonNullElse(
+                signedMessage.unsignedContent(),
+                Component.text(signedMessage.message())
+            );
+        }
+
         final @Nullable CarbonEarlyChatEvent earlyChatEvent = this.prepareAndEmitPreChatEvent(sender, originalMessage);
 
         if (earlyChatEvent == null || earlyChatEvent.cancelled()) {
             return;
         }
 
-        final @Nullable Component parsedMessage = this.parseTags(sender, earlyChatEvent.message());
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, parsedMessage, message.signedMessage(), channel);
+        final Component parsedMessage = this.parseTags(sender, earlyChatEvent.message());
+        if (parsedMessage == null) {
+            return;
+        }
+
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, parsedMessage, signedMessage, channel);
 
         if (chatEvent == null || chatEvent.cancelled()) {
             return;

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
@@ -120,6 +120,10 @@ public final class VelocityChatListener extends ChatListenerInternal implements 
         }
 
         final @Nullable Component message = this.parseTags(sender, earlyChatEvent.message());
+        if (message == null) {
+            return;
+        }
+
         final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, null);
 
         if (chatEvent == null || chatEvent.cancelled()) {


### PR DESCRIPTION
Tested on latest velocity, should prevent `/<channelname> some message` command errors.

Original stack trace:
```
java.lang.NullPointerException: Cannot invoke "net.kyori.adventure.chat.SignedMessage.unsignedContent()" because the return value of "carbonchat.libs.org.incendo.cloud.minecraft.signed.SignedString.signedMessage()" is null
    at net.draycia.carbon.common.channels.CarbonChannelRegistry.sendMessageInChannel(CarbonChannelRegistry.java:349)
    at net.draycia.carbon.common.channels.CarbonChannelRegistry.lambda$registerChannelCommands$3(CarbonChannelRegistry.java:420)
    at carbonchat.libs.org.incendo.cloud.execution.CommandExecutionHandler.executeFuture(CommandExecutionHandler.java:91)
    at carbonchat.libs.org.incendo.cloud.execution.ExecutionCoordinatorImpl.lambda$coordinateExecution$4(ExecutionCoordinatorImpl.java:121)
    at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
    at java.base/java.util.concurrent.CompletableFuture$Completion.run(Unknown Source)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
    at java.base/java.lang.Thread.run(Unknown Source)
```